### PR TITLE
ci: trigger workflow test across all data packages

### DIFF
--- a/.github/workflows/auto-generate-go-packages.yml
+++ b/.github/workflows/auto-generate-go-packages.yml
@@ -226,7 +226,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "chore: auto-regenerate ${{ matrix.package }} Go package"
+            git commit -m "chore: auto-regenerate ${{ matrix.package }} Go package [skip ci]"
             git pull --rebase origin "$BRANCH" || true
             git push origin HEAD:"$BRANCH"
           fi
@@ -384,7 +384,7 @@ jobs:
           fi
 
           PACKAGES_LABEL=$(echo "$PACKAGES" | jq -r 'join(", ")' 2>/dev/null || echo "data packages")
-          git commit -m "chore(go): update go.mod dependencies [${PACKAGES_LABEL}]"
+          git commit -m "chore(go): update go.mod dependencies [${PACKAGES_LABEL}] [skip ci]"
           git push origin HEAD:"$BRANCH"
 
   # Release i18nify-go with updated dependencies (only on master push)

--- a/i18nify-data/bankcodes/proto/bankcodes.proto
+++ b/i18nify-data/bankcodes/proto/bankcodes.proto
@@ -37,3 +37,4 @@ message Identifiers {
   string ifsc_code = 3;
 }
 
+

--- a/i18nify-data/country/metadata/proto/country_metadata.proto
+++ b/i18nify-data/country/metadata/proto/country_metadata.proto
@@ -38,3 +38,4 @@ message LocaleInfo {
   string name = 1;
 }
 
+

--- a/i18nify-data/country/subdivisions/proto/country_subdivisions.proto
+++ b/i18nify-data/country/subdivisions/proto/country_subdivisions.proto
@@ -25,3 +25,4 @@ message City {
   repeated string zipcodes = 4;
 }
 
+

--- a/i18nify-data/currency/proto/currency.proto
+++ b/i18nify-data/currency/proto/currency.proto
@@ -19,3 +19,4 @@ message CurrencyInfo {
   repeated string physical_currency_denominations = 5;
 }
 
+

--- a/i18nify-data/phone-number/country-code-to-phone-number/proto/country_phone_info.proto
+++ b/i18nify-data/phone-number/country-code-to-phone-number/proto/country_phone_info.proto
@@ -15,3 +15,4 @@ message PhoneInfo {
   string regex = 3;
 }
 
+

--- a/packages/i18nify-go/go.mod
+++ b/packages/i18nify-go/go.mod
@@ -12,11 +12,11 @@ require google.golang.org/protobuf v1.31.0 // indirect
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519121342-c504cdf5511e
-	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519121342-c504cdf5511e
-	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519121342-c504cdf5511e
-	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519121342-c504cdf5511e
-	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519121342-c504cdf5511e
+	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519121553-e8d6a9cfce18
+	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519121553-e8d6a9cfce18
+	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519121553-e8d6a9cfce18
+	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519121553-e8d6a9cfce18
+	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519121553-e8d6a9cfce18
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/packages/i18nify-go/go.mod
+++ b/packages/i18nify-go/go.mod
@@ -12,11 +12,11 @@ require google.golang.org/protobuf v1.31.0 // indirect
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519121734-bdb050e044f4
-	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519121734-bdb050e044f4
-	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519121734-bdb050e044f4
-	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519121734-bdb050e044f4
-	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519121734-bdb050e044f4
+	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519121917-07ec7e8586af
+	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519121917-07ec7e8586af
+	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519121917-07ec7e8586af
+	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519121917-07ec7e8586af
+	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519121917-07ec7e8586af
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/packages/i18nify-go/go.mod
+++ b/packages/i18nify-go/go.mod
@@ -19,15 +19,3 @@ require (
 	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519122052-8d578ddd3fa9
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// Local replace directives: these modules live in the same repo and are not
-// yet published to a module proxy. Replace directives make `go` resolve them
-// from disk without hitting sum.golang.org. The release workflow
-// (update-dependencies.sh) drops these and pins real version tags on merge.
-replace (
-	github.com/razorpay/i18nify/i18nify-data/go/bankcodes => ../../i18nify-data/go/bankcodes
-	github.com/razorpay/i18nify/i18nify-data/go/country/metadata => ../../i18nify-data/go/country/metadata
-	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions => ../../i18nify-data/go/country/subdivisions
-	github.com/razorpay/i18nify/i18nify-data/go/currency => ../../i18nify-data/go/currency
-	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number => ../../i18nify-data/go/phone-number/country-code-to-phone-number
-)

--- a/packages/i18nify-go/go.mod
+++ b/packages/i18nify-go/go.mod
@@ -12,11 +12,11 @@ require google.golang.org/protobuf v1.31.0 // indirect
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519121212-0a294547c4ec
-	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519121212-0a294547c4ec
-	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519121212-0a294547c4ec
-	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519121212-0a294547c4ec
-	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519121212-0a294547c4ec
+	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519121342-c504cdf5511e
+	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519121342-c504cdf5511e
+	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519121342-c504cdf5511e
+	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519121342-c504cdf5511e
+	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519121342-c504cdf5511e
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/packages/i18nify-go/go.mod
+++ b/packages/i18nify-go/go.mod
@@ -12,11 +12,11 @@ require google.golang.org/protobuf v1.31.0 // indirect
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519120935-d362999a50b7
-	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519120935-d362999a50b7
-	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519120935-d362999a50b7
-	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519120935-d362999a50b7
-	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519120935-d362999a50b7
+	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519121212-0a294547c4ec
+	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519121212-0a294547c4ec
+	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519121212-0a294547c4ec
+	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519121212-0a294547c4ec
+	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519121212-0a294547c4ec
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/packages/i18nify-go/go.mod
+++ b/packages/i18nify-go/go.mod
@@ -12,11 +12,11 @@ require google.golang.org/protobuf v1.31.0 // indirect
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519121917-07ec7e8586af
-	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519121917-07ec7e8586af
-	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519121917-07ec7e8586af
-	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519121917-07ec7e8586af
-	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519121917-07ec7e8586af
+	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519122052-8d578ddd3fa9
+	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519122052-8d578ddd3fa9
+	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519122052-8d578ddd3fa9
+	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519122052-8d578ddd3fa9
+	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519122052-8d578ddd3fa9
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/packages/i18nify-go/go.mod
+++ b/packages/i18nify-go/go.mod
@@ -12,11 +12,11 @@ require google.golang.org/protobuf v1.31.0 // indirect
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260518124741-65e2850a7e91
-	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260518124741-65e2850a7e91
-	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260518124741-65e2850a7e91
-	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260518124741-65e2850a7e91
-	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260518124741-65e2850a7e91
+	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519120935-d362999a50b7
+	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519120935-d362999a50b7
+	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519120935-d362999a50b7
+	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519120935-d362999a50b7
+	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519120935-d362999a50b7
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/packages/i18nify-go/go.mod
+++ b/packages/i18nify-go/go.mod
@@ -12,11 +12,11 @@ require google.golang.org/protobuf v1.31.0 // indirect
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519121553-e8d6a9cfce18
-	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519121553-e8d6a9cfce18
-	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519121553-e8d6a9cfce18
-	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519121553-e8d6a9cfce18
-	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519121553-e8d6a9cfce18
+	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v0.0.0-20260519121734-bdb050e044f4
+	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v0.0.0-20260519121734-bdb050e044f4
+	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260519121734-bdb050e044f4
+	github.com/razorpay/i18nify/i18nify-data/go/currency v0.0.0-20260519121734-bdb050e044f4
+	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v0.0.0-20260519121734-bdb050e044f4
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 


### PR DESCRIPTION
## Summary
- Adds a blank trailing newline to proto files in all 5 data packages
- Triggers `Auto-Generate Go Packages` CI for all packages to validate the workflow fixes (CI_BOT_TOKEN, race condition fix, update-go-mod job)
- No data content changed

## Packages triggered
- bankcodes
- currency
- country/metadata
- country/subdivisions
- phone-number/country-code-to-phone-number