### PR TITLE
feat(businessEntity): add BusinessEntity JS/TS module

### DIFF
--- a/i18nify-data/business_entity/data.json
+++ b/i18nify-data/business_entity/data.json
@@ -1,0 +1,556 @@
+{
+  "business_entity_information": {
+    "categories": [
+      {
+        "code": "SOLE_PROPRIETORSHIP",
+        "name": "Sole Proprietorship",
+        "description": "A business owned and operated by a single individual with no legal distinction between owner and business."
+      },
+      {
+        "code": "PARTNERSHIP",
+        "name": "Partnership",
+        "description": "A business arrangement where two or more individuals share ownership and management responsibilities."
+      },
+      {
+        "code": "LIMITED_LIABILITY",
+        "name": "Limited Liability Entity",
+        "description": "A business structure that provides personal liability protection for its owners."
+      },
+      {
+        "code": "CORPORATION",
+        "name": "Corporation",
+        "description": "A legal entity that is separate and distinct from its owners, offering the strongest personal liability protection."
+      },
+      {
+        "code": "NON_PROFIT",
+        "name": "Non-Profit Organization",
+        "description": "An organization that operates for purposes other than generating profit for owners or shareholders."
+      },
+      {
+        "code": "COOPERATIVE",
+        "name": "Cooperative",
+        "description": "A business owned and operated by its members who share the benefits and responsibilities."
+      },
+      {
+        "code": "TRUST",
+        "name": "Trust",
+        "description": "A fiduciary arrangement in which assets are managed by a trustee for the benefit of beneficiaries."
+      },
+      {
+        "code": "GOVERNMENT",
+        "name": "Government Entity",
+        "description": "A business or organization owned or controlled by a government body."
+      }
+    ],
+    "sub_categories": {
+      "SOLE_PROPRIETORSHIP": [
+        {
+          "code": "INDIVIDUAL_ENTREPRENEUR",
+          "name": "Individual Entrepreneur",
+          "description": "A self-employed individual running a business independently."
+        },
+        {
+          "code": "FREELANCER",
+          "name": "Freelancer",
+          "description": "An independent contractor offering services to clients without long-term commitment."
+        },
+        {
+          "code": "SELF_EMPLOYED",
+          "name": "Self-Employed",
+          "description": "An individual who works for themselves rather than an employer."
+        }
+      ],
+      "PARTNERSHIP": [
+        {
+          "code": "GENERAL_PARTNERSHIP",
+          "name": "General Partnership",
+          "description": "A partnership where all partners share equal management rights and liability."
+        },
+        {
+          "code": "LIMITED_PARTNERSHIP",
+          "name": "Limited Partnership",
+          "description": "A partnership with at least one general partner and one or more limited partners."
+        },
+        {
+          "code": "LIMITED_LIABILITY_PARTNERSHIP",
+          "name": "Limited Liability Partnership",
+          "description": "A partnership that limits partners' personal liability for the business's debts."
+        }
+      ],
+      "LIMITED_LIABILITY": [
+        {
+          "code": "SINGLE_MEMBER_LLC",
+          "name": "Single-Member LLC",
+          "description": "A limited liability company owned by a single individual."
+        },
+        {
+          "code": "MULTI_MEMBER_LLC",
+          "name": "Multi-Member LLC",
+          "description": "A limited liability company owned by two or more individuals."
+        },
+        {
+          "code": "PROFESSIONAL_LLC",
+          "name": "Professional LLC",
+          "description": "A limited liability company formed by licensed professionals."
+        }
+      ],
+      "CORPORATION": [
+        {
+          "code": "C_CORPORATION",
+          "name": "C Corporation",
+          "description": "A standard corporation taxed separately from its owners."
+        },
+        {
+          "code": "S_CORPORATION",
+          "name": "S Corporation",
+          "description": "A corporation with pass-through taxation, avoiding double taxation."
+        },
+        {
+          "code": "PUBLIC_LIMITED_COMPANY",
+          "name": "Public Limited Company",
+          "description": "A corporation whose shares can be traded publicly on a stock exchange."
+        },
+        {
+          "code": "PRIVATE_LIMITED_COMPANY",
+          "name": "Private Limited Company",
+          "description": "A corporation whose shares are not publicly traded."
+        },
+        {
+          "code": "ONE_PERSON_COMPANY",
+          "name": "One Person Company",
+          "description": "A corporation with a single person as both the director and shareholder."
+        }
+      ],
+      "NON_PROFIT": [
+        {
+          "code": "CHARITABLE_ORGANIZATION",
+          "name": "Charitable Organization",
+          "description": "An organization focused on charitable purposes and public benefit."
+        },
+        {
+          "code": "FOUNDATION",
+          "name": "Foundation",
+          "description": "A non-profit that typically makes grants to other organizations or individuals."
+        },
+        {
+          "code": "ASSOCIATION",
+          "name": "Association",
+          "description": "An organization formed by individuals with a common interest or purpose."
+        },
+        {
+          "code": "NGO",
+          "name": "Non-Governmental Organization",
+          "description": "A non-profit organization operating independently of any government."
+        }
+      ],
+      "COOPERATIVE": [
+        {
+          "code": "WORKER_COOPERATIVE",
+          "name": "Worker Cooperative",
+          "description": "A cooperative owned and managed by its worker-members."
+        },
+        {
+          "code": "CONSUMER_COOPERATIVE",
+          "name": "Consumer Cooperative",
+          "description": "A cooperative owned by its customers who share the benefits."
+        },
+        {
+          "code": "AGRICULTURAL_COOPERATIVE",
+          "name": "Agricultural Cooperative",
+          "description": "A cooperative formed by farmers to improve their marketing power."
+        }
+      ],
+      "TRUST": [
+        {
+          "code": "REVOCABLE_TRUST",
+          "name": "Revocable Trust",
+          "description": "A trust that can be modified or revoked by the grantor during their lifetime."
+        },
+        {
+          "code": "IRREVOCABLE_TRUST",
+          "name": "Irrevocable Trust",
+          "description": "A trust that cannot be modified or terminated without the beneficiary's permission."
+        },
+        {
+          "code": "BUSINESS_TRUST",
+          "name": "Business Trust",
+          "description": "A trust established for commercial purposes."
+        }
+      ],
+      "GOVERNMENT": [
+        {
+          "code": "FEDERAL_AGENCY",
+          "name": "Federal Agency",
+          "description": "An organization that is a part of the federal government."
+        },
+        {
+          "code": "STATE_AGENCY",
+          "name": "State Agency",
+          "description": "An organization that is a part of a state or provincial government."
+        },
+        {
+          "code": "MUNICIPAL_ENTITY",
+          "name": "Municipal Entity",
+          "description": "An organization that is a part of local government."
+        }
+      ]
+    },
+    "entity_types": {
+      "IN": [
+        {
+          "code": "PRIVATE_LIMITED",
+          "name": "Private Limited Company",
+          "abbreviation": "Pvt Ltd",
+          "category": "CORPORATION",
+          "description": "A privately held company with limited liability for shareholders."
+        },
+        {
+          "code": "PUBLIC_LIMITED",
+          "name": "Public Limited Company",
+          "abbreviation": "Ltd",
+          "category": "CORPORATION",
+          "description": "A company whose shares can be publicly traded."
+        },
+        {
+          "code": "ONE_PERSON_COMPANY",
+          "name": "One Person Company",
+          "abbreviation": "OPC",
+          "category": "CORPORATION",
+          "description": "A company with a single person as owner and director."
+        },
+        {
+          "code": "LLP",
+          "name": "Limited Liability Partnership",
+          "abbreviation": "LLP",
+          "category": "PARTNERSHIP",
+          "description": "A partnership that limits partners' personal liability."
+        },
+        {
+          "code": "PARTNERSHIP_FIRM",
+          "name": "Partnership Firm",
+          "abbreviation": "",
+          "category": "PARTNERSHIP",
+          "description": "A business formed by two or more partners."
+        },
+        {
+          "code": "SOLE_PROPRIETORSHIP",
+          "name": "Sole Proprietorship",
+          "abbreviation": "",
+          "category": "SOLE_PROPRIETORSHIP",
+          "description": "A business owned and operated by a single person."
+        },
+        {
+          "code": "TRUST",
+          "name": "Trust",
+          "abbreviation": "",
+          "category": "TRUST",
+          "description": "A fiduciary arrangement for charitable or business purposes."
+        },
+        {
+          "code": "SOCIETY",
+          "name": "Society",
+          "abbreviation": "",
+          "category": "NON_PROFIT",
+          "description": "An organization registered under the Societies Registration Act."
+        },
+        {
+          "code": "SECTION_8_COMPANY",
+          "name": "Section 8 Company",
+          "abbreviation": "",
+          "category": "NON_PROFIT",
+          "description": "A company established for charitable purposes under Section 8 of the Companies Act."
+        },
+        {
+          "code": "NIDHI_COMPANY",
+          "name": "Nidhi Company",
+          "abbreviation": "",
+          "category": "CORPORATION",
+          "description": "A type of NBFC that deals with deposits and lending among members."
+        },
+        {
+          "code": "PRODUCER_COMPANY",
+          "name": "Producer Company",
+          "abbreviation": "",
+          "category": "COOPERATIVE",
+          "description": "A company formed by agricultural producers."
+        }
+      ],
+      "US": [
+        {
+          "code": "LLC",
+          "name": "Limited Liability Company",
+          "abbreviation": "LLC",
+          "category": "LIMITED_LIABILITY",
+          "description": "A flexible business structure providing personal liability protection."
+        },
+        {
+          "code": "C_CORPORATION",
+          "name": "C Corporation",
+          "abbreviation": "Corp",
+          "category": "CORPORATION",
+          "description": "A standard corporation taxed separately from its owners."
+        },
+        {
+          "code": "S_CORPORATION",
+          "name": "S Corporation",
+          "abbreviation": "S Corp",
+          "category": "CORPORATION",
+          "description": "A corporation with pass-through tax treatment."
+        },
+        {
+          "code": "SOLE_PROPRIETORSHIP",
+          "name": "Sole Proprietorship",
+          "abbreviation": "",
+          "category": "SOLE_PROPRIETORSHIP",
+          "description": "The simplest business structure for individual owners."
+        },
+        {
+          "code": "GENERAL_PARTNERSHIP",
+          "name": "General Partnership",
+          "abbreviation": "GP",
+          "category": "PARTNERSHIP",
+          "description": "A partnership where all partners share equal responsibility."
+        },
+        {
+          "code": "LIMITED_PARTNERSHIP",
+          "name": "Limited Partnership",
+          "abbreviation": "LP",
+          "category": "PARTNERSHIP",
+          "description": "A partnership with limited and general partners."
+        },
+        {
+          "code": "LLP",
+          "name": "Limited Liability Partnership",
+          "abbreviation": "LLP",
+          "category": "PARTNERSHIP",
+          "description": "A partnership that protects partners from personal liability."
+        },
+        {
+          "code": "NON_PROFIT_CORPORATION",
+          "name": "Non-Profit Corporation",
+          "abbreviation": "NPC",
+          "category": "NON_PROFIT",
+          "description": "A corporation organized for non-profit purposes."
+        },
+        {
+          "code": "COOPERATIVE",
+          "name": "Cooperative",
+          "abbreviation": "Co-op",
+          "category": "COOPERATIVE",
+          "description": "A business owned and operated by its members."
+        },
+        {
+          "code": "PROFESSIONAL_CORPORATION",
+          "name": "Professional Corporation",
+          "abbreviation": "PC",
+          "category": "CORPORATION",
+          "description": "A corporation formed by licensed professionals."
+        },
+        {
+          "code": "BENEFIT_CORPORATION",
+          "name": "Benefit Corporation",
+          "abbreviation": "PBC",
+          "category": "CORPORATION",
+          "description": "A for-profit corporation committed to public benefit."
+        }
+      ],
+      "GB": [
+        {
+          "code": "PRIVATE_LIMITED",
+          "name": "Private Limited Company",
+          "abbreviation": "Ltd",
+          "category": "CORPORATION",
+          "description": "A company whose shares are privately held."
+        },
+        {
+          "code": "PUBLIC_LIMITED",
+          "name": "Public Limited Company",
+          "abbreviation": "PLC",
+          "category": "CORPORATION",
+          "description": "A company that can offer shares to the general public."
+        },
+        {
+          "code": "LLP",
+          "name": "Limited Liability Partnership",
+          "abbreviation": "LLP",
+          "category": "PARTNERSHIP",
+          "description": "A partnership with limited liability for its members."
+        },
+        {
+          "code": "GENERAL_PARTNERSHIP",
+          "name": "General Partnership",
+          "abbreviation": "",
+          "category": "PARTNERSHIP",
+          "description": "A traditional partnership with shared liability."
+        },
+        {
+          "code": "SOLE_TRADER",
+          "name": "Sole Trader",
+          "abbreviation": "",
+          "category": "SOLE_PROPRIETORSHIP",
+          "description": "A self-employed individual running their own business."
+        },
+        {
+          "code": "COMMUNITY_INTEREST_COMPANY",
+          "name": "Community Interest Company",
+          "abbreviation": "CIC",
+          "category": "NON_PROFIT",
+          "description": "A company designed for social enterprises."
+        },
+        {
+          "code": "CHARITABLE_INCORPORATED_ORGANISATION",
+          "name": "Charitable Incorporated Organisation",
+          "abbreviation": "CIO",
+          "category": "NON_PROFIT",
+          "description": "A charity with a corporate structure."
+        },
+        {
+          "code": "COOPERATIVE",
+          "name": "Cooperative",
+          "abbreviation": "Co-op",
+          "category": "COOPERATIVE",
+          "description": "A business owned and democratically controlled by its members."
+        }
+      ],
+      "SG": [
+        {
+          "code": "PRIVATE_LIMITED",
+          "name": "Private Limited Company",
+          "abbreviation": "Pte Ltd",
+          "category": "CORPORATION",
+          "description": "The most common business structure in Singapore."
+        },
+        {
+          "code": "PUBLIC_LIMITED",
+          "name": "Public Limited Company",
+          "abbreviation": "Ltd",
+          "category": "CORPORATION",
+          "description": "A company whose shares can be publicly traded."
+        },
+        {
+          "code": "SOLE_PROPRIETORSHIP",
+          "name": "Sole Proprietorship",
+          "abbreviation": "",
+          "category": "SOLE_PROPRIETORSHIP",
+          "description": "A business owned and operated by a single individual."
+        },
+        {
+          "code": "GENERAL_PARTNERSHIP",
+          "name": "General Partnership",
+          "abbreviation": "",
+          "category": "PARTNERSHIP",
+          "description": "A partnership with shared liability among partners."
+        },
+        {
+          "code": "LIMITED_PARTNERSHIP",
+          "name": "Limited Partnership",
+          "abbreviation": "LP",
+          "category": "PARTNERSHIP",
+          "description": "A partnership with limited and general partners."
+        },
+        {
+          "code": "LLP",
+          "name": "Limited Liability Partnership",
+          "abbreviation": "LLP",
+          "category": "PARTNERSHIP",
+          "description": "A partnership with limited liability for its members."
+        },
+        {
+          "code": "VARIABLE_CAPITAL_COMPANY",
+          "name": "Variable Capital Company",
+          "abbreviation": "VCC",
+          "category": "CORPORATION",
+          "description": "A corporate structure for investment funds."
+        }
+      ],
+      "AU": [
+        {
+          "code": "PROPRIETARY_LIMITED",
+          "name": "Proprietary Limited Company",
+          "abbreviation": "Pty Ltd",
+          "category": "CORPORATION",
+          "description": "The most common company type in Australia with limited liability."
+        },
+        {
+          "code": "PUBLIC_COMPANY",
+          "name": "Public Company",
+          "abbreviation": "Ltd",
+          "category": "CORPORATION",
+          "description": "A company that can offer shares to the public."
+        },
+        {
+          "code": "SOLE_TRADER",
+          "name": "Sole Trader",
+          "abbreviation": "",
+          "category": "SOLE_PROPRIETORSHIP",
+          "description": "An individual operating a business."
+        },
+        {
+          "code": "PARTNERSHIP",
+          "name": "Partnership",
+          "abbreviation": "",
+          "category": "PARTNERSHIP",
+          "description": "A business structure involving two or more individuals."
+        },
+        {
+          "code": "TRUST",
+          "name": "Trust",
+          "abbreviation": "",
+          "category": "TRUST",
+          "description": "A legal arrangement for holding and managing assets."
+        },
+        {
+          "code": "COOPERATIVE",
+          "name": "Cooperative",
+          "abbreviation": "Co-op",
+          "category": "COOPERATIVE",
+          "description": "A business owned by its members."
+        },
+        {
+          "code": "NOT_FOR_PROFIT",
+          "name": "Not-for-Profit",
+          "abbreviation": "",
+          "category": "NON_PROFIT",
+          "description": "An organisation that does not operate for profit."
+        }
+      ],
+      "MY": [
+        {
+          "code": "PRIVATE_LIMITED",
+          "name": "Private Limited Company",
+          "abbreviation": "Sdn Bhd",
+          "category": "CORPORATION",
+          "description": "A privately held company with limited liability."
+        },
+        {
+          "code": "PUBLIC_LIMITED",
+          "name": "Public Limited Company",
+          "abbreviation": "Bhd",
+          "category": "CORPORATION",
+          "description": "A company whose shares can be traded publicly."
+        },
+        {
+          "code": "SOLE_PROPRIETORSHIP",
+          "name": "Sole Proprietorship",
+          "abbreviation": "",
+          "category": "SOLE_PROPRIETORSHIP",
+          "description": "A business owned and operated by a single person."
+        },
+        {
+          "code": "PARTNERSHIP",
+          "name": "Partnership",
+          "abbreviation": "",
+          "category": "PARTNERSHIP",
+          "description": "A business formed by two or more partners."
+        },
+        {
+          "code": "LLP",
+          "name": "Limited Liability Partnership",
+          "abbreviation": "PLT",
+          "category": "PARTNERSHIP",
+          "description": "A partnership with limited liability for its members."
+        }
+      ]
+    }
+  }
+}

--- a/packages/i18nify-js/src/modules/businessEntity/__tests__/getBusinessCategories.test.ts
+++ b/packages/i18nify-js/src/modules/businessEntity/__tests__/getBusinessCategories.test.ts
@@ -1,0 +1,91 @@
+import getBusinessCategories from '../getBusinessCategories';
+import { BusinessEntityData } from '../types';
+
+const MOCK_DATA: BusinessEntityData = {
+  business_entity_information: {
+    categories: [
+      {
+        code: 'CORPORATION',
+        name: 'Corporation',
+        description: 'A legal entity.',
+      },
+      {
+        code: 'PARTNERSHIP',
+        name: 'Partnership',
+        description: 'Two or more individuals.',
+      },
+    ],
+    sub_categories: {
+      CORPORATION: [
+        {
+          code: 'C_CORPORATION',
+          name: 'C Corporation',
+          description: 'Standard corp.',
+        },
+      ],
+      PARTNERSHIP: [
+        {
+          code: 'GENERAL_PARTNERSHIP',
+          name: 'General Partnership',
+          description: 'Equal partners.',
+        },
+      ],
+    },
+    entity_types: {
+      IN: [
+        {
+          code: 'PRIVATE_LIMITED',
+          name: 'Private Limited Company',
+          abbreviation: 'Pvt Ltd',
+          category: 'CORPORATION',
+          description: 'Pvt Ltd.',
+        },
+      ],
+    },
+  },
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  // Reset the module-level cache between tests.
+  jest.isolateModules(() => {});
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(MOCK_DATA),
+    } as Response),
+  );
+});
+
+describe('getBusinessCategories', () => {
+  it('returns all categories from the data source', async () => {
+    const cats = await getBusinessCategories();
+    expect(cats).toHaveLength(2);
+    expect(cats[0].code).toBe('CORPORATION');
+    expect(cats[1].code).toBe('PARTNERSHIP');
+  });
+
+  it('each category has code, name, and description', async () => {
+    const cats = await getBusinessCategories();
+    for (const cat of cats) {
+      expect(typeof cat.code).toBe('string');
+      expect(cat.code.length).toBeGreaterThan(0);
+      expect(typeof cat.name).toBe('string');
+      expect(cat.name.length).toBeGreaterThan(0);
+      expect(typeof cat.description).toBe('string');
+    }
+  });
+
+  it('throws when fetch fails', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network error')));
+    await expect(getBusinessCategories()).rejects.toThrow();
+  });
+
+  it('throws when HTTP response is not ok', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: false, status: 404 } as Response),
+    );
+    await expect(getBusinessCategories()).rejects.toThrow();
+  });
+});

--- a/packages/i18nify-js/src/modules/businessEntity/__tests__/getBusinessEntityType.test.ts
+++ b/packages/i18nify-js/src/modules/businessEntity/__tests__/getBusinessEntityType.test.ts
@@ -1,0 +1,124 @@
+import getBusinessEntityType from '../getBusinessEntityType';
+import { BusinessEntityData } from '../types';
+
+const MOCK_DATA: BusinessEntityData = {
+  business_entity_information: {
+    categories: [],
+    sub_categories: {},
+    entity_types: {
+      IN: [
+        {
+          code: 'PRIVATE_LIMITED',
+          name: 'Private Limited Company',
+          abbreviation: 'Pvt Ltd',
+          category: 'CORPORATION',
+          description: 'Pvt Ltd.',
+        },
+        {
+          code: 'LLP',
+          name: 'Limited Liability Partnership',
+          abbreviation: 'LLP',
+          category: 'PARTNERSHIP',
+          description: 'LLP.',
+        },
+        {
+          code: 'SOLE_PROPRIETORSHIP',
+          name: 'Sole Proprietorship',
+          abbreviation: '',
+          category: 'SOLE_PROPRIETORSHIP',
+          description: 'Sole prop.',
+        },
+      ],
+      US: [
+        {
+          code: 'LLC',
+          name: 'Limited Liability Company',
+          abbreviation: 'LLC',
+          category: 'LIMITED_LIABILITY',
+          description: 'LLC.',
+        },
+        {
+          code: 'C_CORPORATION',
+          name: 'C Corporation',
+          abbreviation: 'Corp',
+          category: 'CORPORATION',
+          description: 'C Corp.',
+        },
+      ],
+    },
+  },
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(MOCK_DATA),
+    } as Response),
+  );
+});
+
+describe('getBusinessEntityType', () => {
+  it('returns entity types for India (IN)', async () => {
+    const types = await getBusinessEntityType('IN');
+    expect(types).toHaveLength(3);
+    const codes = types.map((t) => t.code);
+    expect(codes).toContain('PRIVATE_LIMITED');
+    expect(codes).toContain('LLP');
+    expect(codes).toContain('SOLE_PROPRIETORSHIP');
+  });
+
+  it('returns entity types for United States (US)', async () => {
+    const types = await getBusinessEntityType('US');
+    expect(types).toHaveLength(2);
+    const codes = types.map((t) => t.code);
+    expect(codes).toContain('LLC');
+    expect(codes).toContain('C_CORPORATION');
+  });
+
+  it('is case-insensitive (lowercase input)', async () => {
+    const types = await getBusinessEntityType('in');
+    expect(types).toHaveLength(3);
+  });
+
+  it('trims surrounding whitespace', async () => {
+    const types = await getBusinessEntityType('  US  ');
+    expect(types).toHaveLength(2);
+  });
+
+  it('each entity type has required fields', async () => {
+    const types = await getBusinessEntityType('IN');
+    for (const et of types) {
+      expect(typeof et.code).toBe('string');
+      expect(et.code.length).toBeGreaterThan(0);
+      expect(typeof et.name).toBe('string');
+      expect(et.name.length).toBeGreaterThan(0);
+      expect(typeof et.category).toBe('string');
+      expect(et.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('throws for empty country code', async () => {
+    await expect(getBusinessEntityType('')).rejects.toThrow('empty');
+  });
+
+  it('throws for unsupported country code', async () => {
+    await expect(getBusinessEntityType('ZZ')).rejects.toThrow(
+      'No entity types found for country code',
+    );
+  });
+
+  it('throws when fetch fails', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network error')));
+    await expect(getBusinessEntityType('IN')).rejects.toThrow();
+  });
+
+  it('throws when HTTP response is not ok', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: false, status: 500 } as Response),
+    );
+    await expect(getBusinessEntityType('IN')).rejects.toThrow();
+  });
+});

--- a/packages/i18nify-js/src/modules/businessEntity/__tests__/getBusinessSubCategories.test.ts
+++ b/packages/i18nify-js/src/modules/businessEntity/__tests__/getBusinessSubCategories.test.ts
@@ -1,0 +1,85 @@
+import getBusinessSubCategories from '../getBusinessSubCategories';
+import { BusinessEntityData } from '../types';
+
+const MOCK_DATA: BusinessEntityData = {
+  business_entity_information: {
+    categories: [
+      { code: 'CORPORATION', name: 'Corporation', description: '' },
+      { code: 'PARTNERSHIP', name: 'Partnership', description: '' },
+    ],
+    sub_categories: {
+      CORPORATION: [
+        {
+          code: 'C_CORPORATION',
+          name: 'C Corporation',
+          description: 'Standard corp.',
+        },
+        {
+          code: 'S_CORPORATION',
+          name: 'S Corporation',
+          description: 'Pass-through.',
+        },
+      ],
+      PARTNERSHIP: [
+        {
+          code: 'GENERAL_PARTNERSHIP',
+          name: 'General Partnership',
+          description: 'Equal partners.',
+        },
+      ],
+    },
+    entity_types: {},
+  },
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(MOCK_DATA),
+    } as Response),
+  );
+});
+
+describe('getBusinessSubCategories', () => {
+  it('returns sub-categories for a known category code', async () => {
+    const subs = await getBusinessSubCategories('CORPORATION');
+    expect(subs).toHaveLength(2);
+    expect(subs[0].code).toBe('C_CORPORATION');
+    expect(subs[1].code).toBe('S_CORPORATION');
+  });
+
+  it('is case-insensitive (lowercase input)', async () => {
+    const subs = await getBusinessSubCategories('corporation');
+    expect(subs).toHaveLength(2);
+  });
+
+  it('trims surrounding whitespace', async () => {
+    const subs = await getBusinessSubCategories('  CORPORATION  ');
+    expect(subs).toHaveLength(2);
+  });
+
+  it('returns different sub-categories for different parent codes', async () => {
+    const corpSubs = await getBusinessSubCategories('CORPORATION');
+    const partnerSubs = await getBusinessSubCategories('PARTNERSHIP');
+    expect(corpSubs).not.toEqual(partnerSubs);
+    expect(partnerSubs[0].code).toBe('GENERAL_PARTNERSHIP');
+  });
+
+  it('throws for empty category code', async () => {
+    await expect(getBusinessSubCategories('')).rejects.toThrow('empty');
+  });
+
+  it('throws for unknown category code', async () => {
+    await expect(getBusinessSubCategories('UNKNOWN_CODE')).rejects.toThrow(
+      'Unknown category code',
+    );
+  });
+
+  it('throws when fetch fails', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network error')));
+    await expect(getBusinessSubCategories('CORPORATION')).rejects.toThrow();
+  });
+});

--- a/packages/i18nify-js/src/modules/businessEntity/data.ts
+++ b/packages/i18nify-js/src/modules/businessEntity/data.ts
@@ -1,0 +1,10 @@
+import { BusinessEntityData } from './types';
+import { I18NIFY_DATA_SOURCE } from '../shared';
+
+export const getBusinessEntityData = async (): Promise<BusinessEntityData> => {
+  const res = await fetch(`${I18NIFY_DATA_SOURCE}/business_entity/data.json`);
+  if (!res.ok) {
+    throw new Error(`Failed to load business entity data: HTTP ${res.status}`);
+  }
+  return (await res.json()) as BusinessEntityData;
+};

--- a/packages/i18nify-js/src/modules/businessEntity/getBusinessCategories.ts
+++ b/packages/i18nify-js/src/modules/businessEntity/getBusinessCategories.ts
@@ -1,0 +1,25 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { BusinessCategory } from './types';
+import { getBusinessEntityData } from './data';
+
+/**
+ * Returns all top-level business categories.
+ *
+ * @returns {Promise<BusinessCategory[]>} Array of business categories
+ *
+ * @example
+ * const categories = await getBusinessCategories();
+ * // [{ code: 'CORPORATION', name: 'Corporation', description: '...' }, ...]
+ */
+const getBusinessCategories = async (): Promise<BusinessCategory[]> => {
+  const data = await getBusinessEntityData().catch((err) => {
+    throw new Error(
+      `An error occurred while fetching business entity data. The error details are: ${err.message}.`,
+    );
+  });
+  return data.business_entity_information.categories;
+};
+
+export default withErrorBoundary<typeof getBusinessCategories>(
+  getBusinessCategories,
+);

--- a/packages/i18nify-js/src/modules/businessEntity/getBusinessEntityType.ts
+++ b/packages/i18nify-js/src/modules/businessEntity/getBusinessEntityType.ts
@@ -1,0 +1,40 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { BusinessEntityType } from './types';
+import { getBusinessEntityData } from './data';
+
+/**
+ * Returns the legal entity types available for a given ISO 3166-1 alpha-2 country code.
+ *
+ * @param {string} countryCode - ISO 3166-1 alpha-2 country code (e.g., "IN", "US")
+ * @returns {Promise<BusinessEntityType[]>} Array of entity types for the country
+ *
+ * @throws {Error} When countryCode is empty or unsupported
+ *
+ * @example
+ * const types = await getBusinessEntityType('IN');
+ * // [{ code: 'PRIVATE_LIMITED', name: 'Private Limited Company', abbreviation: 'Pvt Ltd', ... }, ...]
+ */
+const getBusinessEntityType = async (
+  countryCode: string,
+): Promise<BusinessEntityType[]> => {
+  const cc = countryCode?.trim().toUpperCase();
+  if (!cc) {
+    throw new Error('countryCode must not be empty');
+  }
+
+  const data = await getBusinessEntityData().catch((err) => {
+    throw new Error(
+      `An error occurred while fetching business entity data. The error details are: ${err.message}.`,
+    );
+  });
+
+  const types = data.business_entity_information.entity_types[cc];
+  if (!types) {
+    throw new Error(`No entity types found for country code: "${cc}"`);
+  }
+  return types;
+};
+
+export default withErrorBoundary<typeof getBusinessEntityType>(
+  getBusinessEntityType,
+);

--- a/packages/i18nify-js/src/modules/businessEntity/getBusinessSubCategories.ts
+++ b/packages/i18nify-js/src/modules/businessEntity/getBusinessSubCategories.ts
@@ -1,0 +1,40 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { BusinessSubCategory } from './types';
+import { getBusinessEntityData } from './data';
+
+/**
+ * Returns sub-categories for a given business category code.
+ *
+ * @param {string} categoryCode - The business category code (e.g., "CORPORATION")
+ * @returns {Promise<BusinessSubCategory[]>} Array of sub-categories
+ *
+ * @throws {Error} When categoryCode is empty or unknown
+ *
+ * @example
+ * const subs = await getBusinessSubCategories('CORPORATION');
+ * // [{ code: 'C_CORPORATION', name: 'C Corporation', description: '...' }, ...]
+ */
+const getBusinessSubCategories = async (
+  categoryCode: string,
+): Promise<BusinessSubCategory[]> => {
+  const code = categoryCode?.trim().toUpperCase();
+  if (!code) {
+    throw new Error('categoryCode must not be empty');
+  }
+
+  const data = await getBusinessEntityData().catch((err) => {
+    throw new Error(
+      `An error occurred while fetching business entity data. The error details are: ${err.message}.`,
+    );
+  });
+
+  const subs = data.business_entity_information.sub_categories[code];
+  if (!subs) {
+    throw new Error(`Unknown category code: "${code}"`);
+  }
+  return subs;
+};
+
+export default withErrorBoundary<typeof getBusinessSubCategories>(
+  getBusinessSubCategories,
+);

--- a/packages/i18nify-js/src/modules/businessEntity/index.ts
+++ b/packages/i18nify-js/src/modules/businessEntity/index.ts
@@ -1,0 +1,9 @@
+export { default as getBusinessCategories } from './getBusinessCategories';
+export { default as getBusinessSubCategories } from './getBusinessSubCategories';
+export { default as getBusinessEntityType } from './getBusinessEntityType';
+export type {
+  BusinessCategory,
+  BusinessSubCategory,
+  BusinessEntityType,
+  BusinessEntityData,
+} from './types';

--- a/packages/i18nify-js/src/modules/businessEntity/types.ts
+++ b/packages/i18nify-js/src/modules/businessEntity/types.ts
@@ -1,0 +1,27 @@
+export interface BusinessCategory {
+  code: string;
+  name: string;
+  description: string;
+}
+
+export interface BusinessSubCategory {
+  code: string;
+  name: string;
+  description: string;
+}
+
+export interface BusinessEntityType {
+  code: string;
+  name: string;
+  abbreviation: string;
+  category: string;
+  description: string;
+}
+
+export interface BusinessEntityData {
+  business_entity_information: {
+    categories: BusinessCategory[];
+    sub_categories: Record<string, BusinessSubCategory[]>;
+    entity_types: Record<string, BusinessEntityType[]>;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `businessEntity` module to `@razorpay/i18nify-js` with three functions:
  - `getBusinessCategories()` — returns 8 top-level business categories (Sole Proprietorship, Partnership, LLC, Corporation, Non-Profit, Cooperative, Trust, Government)
  - `getBusinessSubCategories(categoryCode)` — returns sub-categories for a given parent category code
  - `getBusinessEntityType(countryCode)` — returns legal entity types for IN, US, GB, SG, AU, MY; case-insensitive, whitespace-tolerant
- Adds canonical data at `i18nify-data/business_entity/data.json`

## Test plan

- [ ] 23 unit tests across `getBusinessCategories`, `getBusinessSubCategories`, `getBusinessEntityType`
- [ ] Run: `yarn workspace @razorpay/i18nify-js test`

## Related

Part of a split from #639. See also:
- Go implementation: `feat/business-entity-go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)