### PR TITLE
feat(banking): add getBankCode and getBankNameByCode to JS module

### DIFF
--- a/packages/i18nify-js/src/modules/banking/__tests__/getBankCode.test.ts
+++ b/packages/i18nify-js/src/modules/banking/__tests__/getBankCode.test.ts
@@ -1,0 +1,114 @@
+import { getBankCode } from '../index';
+
+global.fetch = jest.fn();
+
+describe('getBankCode', () => {
+  const mockCountryCode = 'IN';
+  const mockBankData = {
+    details: [
+      { name: 'State Bank of India', short_code: 'SBIN' },
+      { name: 'HDFC Bank', short_code: 'HDFC' },
+    ],
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should return the short code for a valid bank name', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockBankData),
+    });
+
+    const code = await getBankCode(mockCountryCode, 'HDFC Bank');
+    expect(code).toBe('HDFC');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`${mockCountryCode}.json`),
+    );
+  });
+
+  test('should perform case-insensitive bank name matching', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockBankData),
+    });
+
+    const code = await getBankCode(mockCountryCode, 'state bank of india');
+    expect(code).toBe('SBIN');
+  });
+
+  test('should throw an error for an invalid country code', async () => {
+    const invalidCountryCode = 'XX';
+    await expect(
+      getBankCode(invalidCountryCode as any, 'HDFC Bank'),
+    ).rejects.toThrow(
+      `Data not available for country code: ${invalidCountryCode}.`,
+    );
+  });
+
+  test('should throw an error when bank name is empty', async () => {
+    await expect(getBankCode(mockCountryCode, '')).rejects.toThrow(
+      'Bank name must not be empty.',
+    );
+  });
+
+  test('should throw an error when bank name is whitespace only', async () => {
+    await expect(getBankCode(mockCountryCode, '   ')).rejects.toThrow(
+      'Bank name must not be empty.',
+    );
+  });
+
+  test('should throw an error when no bank matches the name', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockBankData),
+    });
+
+    await expect(
+      getBankCode(mockCountryCode, 'Nonexistent Bank'),
+    ).rejects.toThrow('No bank found with name "Nonexistent Bank"');
+  });
+
+  test('should throw an error for a bank that has no short code', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        details: [{ name: 'No Code Bank', short_code: '' }],
+      }),
+    });
+
+    await expect(getBankCode(mockCountryCode, 'No Code Bank')).rejects.toThrow(
+      'Bank "No Code Bank" in country IN does not have a short code.',
+    );
+  });
+
+  test('should throw an error when API responds with non-2xx status', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(getBankCode(mockCountryCode, 'HDFC Bank')).rejects.toThrow(
+      `Failed to load bank data for country: ${mockCountryCode}.`,
+    );
+  });
+
+  test('should handle network failure gracefully', async () => {
+    (fetch as jest.Mock).mockRejectedValue(new Error('Network Error'));
+
+    await expect(getBankCode(mockCountryCode, 'HDFC Bank')).rejects.toThrow(
+      'An error occurred while fetching bank data. The error details are: Network Error.',
+    );
+  });
+
+  test('should handle missing details key in response gracefully', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({}), // Missing `details`
+    });
+
+    await expect(getBankCode(mockCountryCode, 'HDFC Bank')).rejects.toThrow(
+      'No bank found with name "HDFC Bank"',
+    );
+  });
+});

--- a/packages/i18nify-js/src/modules/banking/__tests__/getBankNameByCode.test.ts
+++ b/packages/i18nify-js/src/modules/banking/__tests__/getBankNameByCode.test.ts
@@ -1,0 +1,101 @@
+import { getBankNameByCode } from '../index';
+
+global.fetch = jest.fn();
+
+describe('getBankNameByCode', () => {
+  const mockCountryCode = 'IN';
+  const mockBankData = {
+    details: [
+      { name: 'State Bank of India', short_code: 'SBIN' },
+      { name: 'HDFC Bank', short_code: 'HDFC' },
+    ],
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should return the bank name for a valid short code', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockBankData),
+    });
+
+    const name = await getBankNameByCode(mockCountryCode, 'SBIN');
+    expect(name).toBe('State Bank of India');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`${mockCountryCode}.json`),
+    );
+  });
+
+  test('should perform case-insensitive short code matching', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockBankData),
+    });
+
+    const name = await getBankNameByCode(mockCountryCode, 'hdfc');
+    expect(name).toBe('HDFC Bank');
+  });
+
+  test('should throw an error for an invalid country code', async () => {
+    const invalidCountryCode = 'XX';
+    await expect(
+      getBankNameByCode(invalidCountryCode as any, 'SBIN'),
+    ).rejects.toThrow(
+      `Data not available for country code: ${invalidCountryCode}.`,
+    );
+  });
+
+  test('should throw an error when bank code is empty', async () => {
+    await expect(getBankNameByCode(mockCountryCode, '')).rejects.toThrow(
+      'Bank code must not be empty.',
+    );
+  });
+
+  test('should throw an error when bank code is whitespace only', async () => {
+    await expect(getBankNameByCode(mockCountryCode, '   ')).rejects.toThrow(
+      'Bank code must not be empty.',
+    );
+  });
+
+  test('should throw an error when no bank matches the short code', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockBankData),
+    });
+
+    await expect(getBankNameByCode(mockCountryCode, 'ZZZZ')).rejects.toThrow(
+      'No bank found with short code "ZZZZ"',
+    );
+  });
+
+  test('should throw an error when API responds with non-2xx status', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(getBankNameByCode(mockCountryCode, 'SBIN')).rejects.toThrow(
+      `Failed to load bank data for country: ${mockCountryCode}.`,
+    );
+  });
+
+  test('should handle network failure gracefully', async () => {
+    (fetch as jest.Mock).mockRejectedValue(new Error('Network Error'));
+
+    await expect(getBankNameByCode(mockCountryCode, 'SBIN')).rejects.toThrow(
+      'An error occurred while fetching bank data. The error details are: Network Error.',
+    );
+  });
+
+  test('should handle missing details key in response gracefully', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({}), // Missing `details`
+    });
+
+    await expect(getBankNameByCode(mockCountryCode, 'SBIN')).rejects.toThrow(
+      'No bank found with short code "SBIN"',
+    );
+  });
+});

--- a/packages/i18nify-js/src/modules/banking/getBankCode.ts
+++ b/packages/i18nify-js/src/modules/banking/getBankCode.ts
@@ -1,0 +1,97 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { I18nifyCountryCodeType } from '../geo/types';
+import {
+  I18NIFY_DATA_SOURCE,
+  I18NIFY_DATA_SUPPORTED_COUNTRIES,
+} from '../shared';
+
+/**
+ * Retrieves the short code for a bank given its full name within a country.
+ *
+ * This function makes a network request to the central i18nify-data source,
+ * locates the bank whose `name` matches (case-insensitive), and returns its
+ * `short_code`.
+ *
+ * It is the logical complement of `getBankNameByCode`: where that function
+ * maps short code → name, this function maps name → short code. Together they
+ * mirror the bidirectional lookup available in the Go i18nify-go bankcodes
+ * module via `GetBankNameFromShortCode` and `GetAllBanksWithShortCodes`.
+ *
+ * @param {I18nifyCountryCodeType} _countryCode - ISO 3166-1 alpha-2 country code.
+ *   Only "IN", "MY", "SG", and "US" are supported.
+ * @param {string} bankName - The bank's full display name (e.g., "HDFC Bank").
+ *   Comparison is case-insensitive.
+ * @returns {Promise<string>} A promise resolving to the bank's short code
+ *   (e.g., "HDFC").
+ * @throws {Error} If the country code is unsupported, the bank name is empty,
+ *   no bank with that name is found, or the matched bank has no short code.
+ *
+ * @example
+ * getBankCode('IN', 'HDFC Bank')
+ *   .then((code) => console.log(code));
+ * // → "HDFC"
+ *
+ * @example
+ * getBankCode('US', 'Bank of America')
+ *   .then((code) => console.log(code));
+ */
+const getBankCode = (
+  _countryCode: I18nifyCountryCodeType,
+  bankName: string,
+): Promise<string> => {
+  if (!bankName || !bankName.trim()) {
+    return Promise.reject(new Error('Bank name must not be empty.'));
+  }
+
+  const countryCode = _countryCode.toUpperCase();
+
+  if (I18NIFY_DATA_SUPPORTED_COUNTRIES.indexOf(countryCode) === -1) {
+    return Promise.reject(
+      new Error(
+        `Data not available for country code: ${countryCode}. Data only available for country codes mentioned here: https://github.com/razorpay/i18nify/blob/master/packages/i18nify-js/src/modules/geo/constants.ts#L8`,
+      ),
+    );
+  }
+
+  const normalizedName = bankName.trim().toLowerCase();
+
+  return fetch(`${I18NIFY_DATA_SOURCE}/bankcodes/${countryCode}.json`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(
+          `Failed to load bank data for country: ${countryCode}.`,
+        );
+      }
+      return res.json();
+    })
+    .then((data) => {
+      const banks: Array<{ name: string; short_code: string }> =
+        data.details || [];
+
+      // Case-insensitive name match — mirrors Go's strings.EqualFold behaviour
+      const bank = banks.find(
+        (b) => b.name && b.name.toLowerCase() === normalizedName,
+      );
+
+      if (!bank) {
+        throw new Error(
+          `No bank found with name "${bankName}" in country: ${countryCode}.`,
+        );
+      }
+
+      if (!bank.short_code) {
+        throw new Error(
+          `Bank "${bankName}" in country ${countryCode} does not have a short code.`,
+        );
+      }
+
+      return bank.short_code;
+    })
+    .catch((err) => {
+      throw new Error(
+        `An error occurred while fetching bank data. The error details are: ${err.message}.`,
+      );
+    });
+};
+
+export default withErrorBoundary<typeof getBankCode>(getBankCode);

--- a/packages/i18nify-js/src/modules/banking/getBankNameByCode.ts
+++ b/packages/i18nify-js/src/modules/banking/getBankNameByCode.ts
@@ -1,0 +1,89 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { I18nifyCountryCodeType } from '../geo/types';
+import {
+  I18NIFY_DATA_SOURCE,
+  I18NIFY_DATA_SUPPORTED_COUNTRIES,
+} from '../shared';
+
+/**
+ * Retrieves the full bank name for a given short code within a country.
+ *
+ * This function makes a network request to the central i18nify-data source,
+ * locates the bank whose `short_code` matches (case-insensitive), and returns
+ * its full display name.
+ *
+ * It mirrors the Go `GetBankNameFromShortCode(countryCode, shortCode)` function
+ * in the i18nify-go bankcodes module, which performs the same case-insensitive
+ * short-code lookup and returns the bank name or an error when not found.
+ *
+ * @param {I18nifyCountryCodeType} _countryCode - ISO 3166-1 alpha-2 country code.
+ *   Only "IN", "MY", "SG", and "US" are supported.
+ * @param {string} bankCode - The bank's short code (e.g., "HDFC", "SBIN").
+ *   Comparison is case-insensitive.
+ * @returns {Promise<string>} A promise resolving to the bank's full name.
+ * @throws {Error} If the country code is unsupported, the bank code is empty,
+ *   or no bank with the given short code is found.
+ *
+ * @example
+ * getBankNameByCode('IN', 'HDFC')
+ *   .then((name) => console.log(name));
+ * // → "HDFC Bank"
+ *
+ * @example
+ * getBankNameByCode('US', 'BOFAUS3N')
+ *   .then((name) => console.log(name));
+ */
+const getBankNameByCode = (
+  _countryCode: I18nifyCountryCodeType,
+  bankCode: string,
+): Promise<string> => {
+  if (!bankCode || !bankCode.trim()) {
+    return Promise.reject(new Error('Bank code must not be empty.'));
+  }
+
+  const countryCode = _countryCode.toUpperCase();
+
+  if (I18NIFY_DATA_SUPPORTED_COUNTRIES.indexOf(countryCode) === -1) {
+    return Promise.reject(
+      new Error(
+        `Data not available for country code: ${countryCode}. Data only available for country codes mentioned here: https://github.com/razorpay/i18nify/blob/master/packages/i18nify-js/src/modules/geo/constants.ts#L8`,
+      ),
+    );
+  }
+
+  const normalizedCode = bankCode.trim().toUpperCase();
+
+  return fetch(`${I18NIFY_DATA_SOURCE}/bankcodes/${countryCode}.json`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(
+          `Failed to load bank data for country: ${countryCode}.`,
+        );
+      }
+      return res.json();
+    })
+    .then((data) => {
+      const banks: Array<{ name: string; short_code: string }> =
+        data.details || [];
+
+      // Case-insensitive short_code match — mirrors Go's strings.EqualFold
+      const bank = banks.find(
+        (b) => b.short_code && b.short_code.toUpperCase() === normalizedCode,
+      );
+
+      if (!bank) {
+        throw new Error(
+          `No bank found with short code "${bankCode}" in country: ${countryCode}.`,
+        );
+      }
+
+      return bank.name;
+    })
+    .catch((err) => {
+      throw new Error(
+        `An error occurred while fetching bank data. The error details are: ${err.message}.`,
+      );
+    });
+};
+
+export default withErrorBoundary<typeof getBankNameByCode>(getBankNameByCode);


### PR DESCRIPTION
## Summary

- Adds two new functions to the existing JS `banking` module:
  - `getBankCode(countryCode, bankName)` — maps full bank name → short code (case-insensitive); complements `getListOfBanks`
  - `getBankNameByCode(countryCode, shortCode)` — maps short code → full bank name (case-insensitive)
- Mirrors bidirectional lookup already available in Go bankcodes module
- Supported countries: IN, MY, SG, US

## Test plan

- [ ] Run: `yarn workspace @razorpay/i18nify-js test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)