### PR TITLE
feat(names): add Names JS/TS module

### DIFF
--- a/i18nify-data/names/data.json
+++ b/i18nify-data/names/data.json
@@ -1,0 +1,83 @@
+{
+  "names_information": {
+    "honorific_titles": {
+      "english": [
+        {"code": "MR", "title": "Mr.", "gender": "male", "description": "Title for men"},
+        {"code": "MRS", "title": "Mrs.", "gender": "female", "description": "Title for married women"},
+        {"code": "MS", "title": "Ms.", "gender": "female", "description": "Title for women, regardless of marital status"},
+        {"code": "MISS", "title": "Miss", "gender": "female", "description": "Title for unmarried women"},
+        {"code": "MX", "title": "Mx.", "gender": "neutral", "description": "Gender-neutral title"},
+        {"code": "DR", "title": "Dr.", "gender": "neutral", "description": "Title for holders of doctoral degrees or medical doctors"},
+        {"code": "PROF", "title": "Prof.", "gender": "neutral", "description": "Title for professors"},
+        {"code": "REV", "title": "Rev.", "gender": "neutral", "description": "Title for religious clergy"},
+        {"code": "SIR", "title": "Sir", "gender": "male", "description": "Title for knights and baronets"},
+        {"code": "DAME", "title": "Dame", "gender": "female", "description": "Title for female equivalents of knights"},
+        {"code": "LORD", "title": "Lord", "gender": "male", "description": "Title for nobility"},
+        {"code": "LADY", "title": "Lady", "gender": "female", "description": "Title for female nobility"},
+        {"code": "ESQ", "title": "Esq.", "gender": "neutral", "description": "Courtesy title for lawyers"}
+      ],
+      "hindi": [
+        {"code": "SHRI", "title": "Shri", "gender": "male", "description": "Respectful title for men"},
+        {"code": "SMT", "title": "Smt.", "gender": "female", "description": "Respectful title for married women"},
+        {"code": "KM", "title": "Km.", "gender": "female", "description": "Title for unmarried women"},
+        {"code": "DR", "title": "Dr.", "gender": "neutral", "description": "Title for doctors"},
+        {"code": "PROF", "title": "Prof.", "gender": "neutral", "description": "Title for professors"}
+      ],
+      "french": [
+        {"code": "M", "title": "M.", "gender": "male", "description": "Title for men"},
+        {"code": "MME", "title": "Mme", "gender": "female", "description": "Title for women"},
+        {"code": "DR", "title": "Dr.", "gender": "neutral", "description": "Title for doctors"},
+        {"code": "PROF", "title": "Prof.", "gender": "neutral", "description": "Title for professors"}
+      ],
+      "german": [
+        {"code": "HERR", "title": "Herr", "gender": "male", "description": "Title for men"},
+        {"code": "FRAU", "title": "Frau", "gender": "female", "description": "Title for women"},
+        {"code": "DR", "title": "Dr.", "gender": "neutral", "description": "Title for doctors"},
+        {"code": "PROF", "title": "Prof.", "gender": "neutral", "description": "Title for professors"}
+      ],
+      "spanish": [
+        {"code": "SR", "title": "Sr.", "gender": "male", "description": "Title for men"},
+        {"code": "SRA", "title": "Sra.", "gender": "female", "description": "Title for married women"},
+        {"code": "SRTA", "title": "Srta.", "gender": "female", "description": "Title for unmarried women"},
+        {"code": "DR", "title": "Dr.", "gender": "neutral", "description": "Title for doctors"},
+        {"code": "PROF", "title": "Prof.", "gender": "neutral", "description": "Title for professors"}
+      ],
+      "arabic": [
+        {"code": "AL_SAYYID", "title": "السيد", "gender": "male", "description": "Title for men"},
+        {"code": "AL_SAYYIDA", "title": "السيدة", "gender": "female", "description": "Title for women"},
+        {"code": "AL_ANISA", "title": "الآنسة", "gender": "female", "description": "Title for unmarried women"},
+        {"code": "AL_DOCTOR", "title": "الدكتور", "gender": "neutral", "description": "Title for doctors"},
+        {"code": "AL_USTADH", "title": "الأستاذ", "gender": "neutral", "description": "Title for professors"}
+      ],
+      "japanese": [
+        {"code": "SAMA", "title": "様", "gender": "neutral", "description": "Highly respectful honorific"},
+        {"code": "SAN", "title": "さん", "gender": "neutral", "description": "Standard polite honorific"},
+        {"code": "KUN", "title": "くん", "gender": "male", "description": "Informal honorific for males"},
+        {"code": "CHAN", "title": "ちゃん", "gender": "neutral", "description": "Affectionate honorific"},
+        {"code": "SENSEI", "title": "先生", "gender": "neutral", "description": "Title for teachers and doctors"}
+      ],
+      "chinese": [
+        {"code": "XIANSHENG", "title": "先生", "gender": "male", "description": "Title for men"},
+        {"code": "NVSHI", "title": "女士", "gender": "female", "description": "Title for women"},
+        {"code": "BOSHI", "title": "博士", "gender": "neutral", "description": "Title for doctoral degree holders"},
+        {"code": "JIAOSHOU", "title": "教授", "gender": "neutral", "description": "Title for professors"}
+      ],
+      "portuguese": [
+        {"code": "SR", "title": "Sr.", "gender": "male", "description": "Title for men"},
+        {"code": "SRA", "title": "Sra.", "gender": "female", "description": "Title for women"},
+        {"code": "DR", "title": "Dr.", "gender": "neutral", "description": "Title for doctors"},
+        {"code": "PROF", "title": "Prof.", "gender": "neutral", "description": "Title for professors"}
+      ],
+      "russian": [
+        {"code": "GOSPODIN", "title": "Господин", "gender": "male", "description": "Title for men"},
+        {"code": "GOSPOZHA", "title": "Госпожа", "gender": "female", "description": "Title for women"},
+        {"code": "DR", "title": "Д-р", "gender": "neutral", "description": "Title for doctors"},
+        {"code": "PROF", "title": "Проф.", "gender": "neutral", "description": "Title for professors"}
+      ]
+    },
+    "validation_rules": {
+      "min_length": 2,
+      "max_length": 100
+    }
+  }
+}

--- a/packages/i18nify-js/src/modules/names/__tests__/getHonorificTitles.test.ts
+++ b/packages/i18nify-js/src/modules/names/__tests__/getHonorificTitles.test.ts
@@ -1,0 +1,142 @@
+import getHonorificTitles from '../getHonorificTitles';
+import { NamesData } from '../types';
+
+const MOCK_DATA: NamesData = {
+  names_information: {
+    honorific_titles: {
+      english: [
+        {
+          code: 'MR',
+          title: 'Mr.',
+          gender: 'male',
+          description: 'Title for men',
+        },
+        {
+          code: 'MRS',
+          title: 'Mrs.',
+          gender: 'female',
+          description: 'Title for married women',
+        },
+        {
+          code: 'DR',
+          title: 'Dr.',
+          gender: 'neutral',
+          description: 'Title for doctors',
+        },
+      ],
+      hindi: [
+        {
+          code: 'SHRI',
+          title: 'Shri',
+          gender: 'male',
+          description: 'Respectful title for men',
+        },
+        {
+          code: 'SMT',
+          title: 'Smt.',
+          gender: 'female',
+          description: 'Respectful title for married women',
+        },
+      ],
+      french: [
+        {
+          code: 'M',
+          title: 'M.',
+          gender: 'male',
+          description: 'Title for men',
+        },
+        {
+          code: 'MME',
+          title: 'Mme',
+          gender: 'female',
+          description: 'Title for women',
+        },
+      ],
+    },
+    validation_rules: { min_length: 2, max_length: 100 },
+  },
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(MOCK_DATA),
+    } as Response),
+  );
+});
+
+describe('getHonorificTitles', () => {
+  it('returns titles for English (en)', async () => {
+    const titles = await getHonorificTitles('en');
+    expect(titles).toHaveLength(3);
+    const codes = titles.map((t) => t.code);
+    expect(codes).toContain('MR');
+    expect(codes).toContain('MRS');
+    expect(codes).toContain('DR');
+  });
+
+  it('returns titles for Hindi (hi)', async () => {
+    const titles = await getHonorificTitles('hi');
+    expect(titles).toHaveLength(2);
+    const codes = titles.map((t) => t.code);
+    expect(codes).toContain('SHRI');
+    expect(codes).toContain('SMT');
+  });
+
+  it('returns titles for French (fr)', async () => {
+    const titles = await getHonorificTitles('fr');
+    expect(titles).toHaveLength(2);
+  });
+
+  it('is case-insensitive (uppercase locale)', async () => {
+    const titles = await getHonorificTitles('EN');
+    expect(titles).toHaveLength(3);
+  });
+
+  it('strips BCP 47 region subtag (en-US → en)', async () => {
+    const enUS = await getHonorificTitles('en-US');
+    const en = await getHonorificTitles('en');
+    expect(enUS).toEqual(en);
+  });
+
+  it('trims surrounding whitespace', async () => {
+    const titles = await getHonorificTitles('  en  ');
+    expect(titles).toHaveLength(3);
+  });
+
+  it('each title has code, title, gender, and description', async () => {
+    const titles = await getHonorificTitles('en');
+    for (const t of titles) {
+      expect(typeof t.code).toBe('string');
+      expect(t.code.length).toBeGreaterThan(0);
+      expect(typeof t.title).toBe('string');
+      expect(t.title.length).toBeGreaterThan(0);
+      expect(['male', 'female', 'neutral']).toContain(t.gender);
+    }
+  });
+
+  it('throws for empty locale', async () => {
+    await expect(getHonorificTitles('')).rejects.toThrow('empty');
+  });
+
+  it('throws for unsupported locale', async () => {
+    await expect(getHonorificTitles('zz')).rejects.toThrow(
+      'No honorific titles found for locale',
+    );
+  });
+
+  it('throws when fetch fails', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network error')));
+    await expect(getHonorificTitles('en')).rejects.toThrow();
+  });
+
+  it('throws when HTTP response is not ok', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: false, status: 503 } as Response),
+    );
+    await expect(getHonorificTitles('en')).rejects.toThrow();
+  });
+});

--- a/packages/i18nify-js/src/modules/names/__tests__/isValidName.test.ts
+++ b/packages/i18nify-js/src/modules/names/__tests__/isValidName.test.ts
@@ -1,0 +1,101 @@
+import isValidName from '../isValidName';
+
+describe('isValidName', () => {
+  // --- Valid names ---
+  it('accepts a simple ASCII name', () => {
+    expect(isValidName('John')).toBe(true);
+  });
+
+  it('accepts a full name with space', () => {
+    expect(isValidName('John Smith')).toBe(true);
+  });
+
+  it('accepts a hyphenated surname', () => {
+    expect(isValidName('Mary-Jane Watson')).toBe(true);
+  });
+
+  it("accepts an apostrophe surname (O'Brien)", () => {
+    expect(isValidName("O'Brien")).toBe(true);
+  });
+
+  it('accepts a name with a period (Dr. Smith)', () => {
+    expect(isValidName('Dr. Smith')).toBe(true);
+  });
+
+  it('accepts a 2-character name (minimum)', () => {
+    expect(isValidName('Jo')).toBe(true);
+  });
+
+  it('accepts a 100-character name (maximum)', () => {
+    expect(isValidName('A'.repeat(100))).toBe(true);
+  });
+
+  it('accepts names with leading/trailing spaces (trimmed)', () => {
+    expect(isValidName('  Alice  ')).toBe(true);
+  });
+
+  it('accepts Unicode letters – Hindi', () => {
+    expect(isValidName('रामलाल')).toBe(true);
+  });
+
+  it('accepts Unicode letters – Arabic', () => {
+    expect(isValidName('محمد')).toBe(true);
+  });
+
+  it('accepts Unicode letters – Chinese', () => {
+    expect(isValidName('李明')).toBe(true);
+  });
+
+  it('accepts Unicode letters – Japanese', () => {
+    expect(isValidName('田中')).toBe(true);
+  });
+
+  // --- Invalid names ---
+  it('rejects an empty string', () => {
+    expect(isValidName('')).toBe(false);
+  });
+
+  it('rejects a single character', () => {
+    expect(isValidName('A')).toBe(false);
+  });
+
+  it('rejects a string of only spaces', () => {
+    expect(isValidName('   ')).toBe(false);
+  });
+
+  it('rejects a name with digits', () => {
+    expect(isValidName('John2')).toBe(false);
+  });
+
+  it('rejects a string of only digits', () => {
+    expect(isValidName('12345')).toBe(false);
+  });
+
+  it('rejects a name with @ character', () => {
+    expect(isValidName('John@Doe')).toBe(false);
+  });
+
+  it('rejects a name with # character', () => {
+    expect(isValidName('John#')).toBe(false);
+  });
+
+  it('rejects a name exceeding 100 characters', () => {
+    expect(isValidName('A'.repeat(101))).toBe(false);
+  });
+
+  it('rejects a name with a tab character', () => {
+    expect(isValidName('John\tDoe')).toBe(false);
+  });
+
+  it('rejects a name with a newline character', () => {
+    expect(isValidName('John\nDoe')).toBe(false);
+  });
+
+  it('rejects a name with underscore', () => {
+    expect(isValidName('John_Doe')).toBe(false);
+  });
+
+  it('rejects a name with an exclamation mark', () => {
+    expect(isValidName('Alice!')).toBe(false);
+  });
+});

--- a/packages/i18nify-js/src/modules/names/data.ts
+++ b/packages/i18nify-js/src/modules/names/data.ts
@@ -1,0 +1,10 @@
+import { NamesData } from './types';
+import { I18NIFY_DATA_SOURCE } from '../shared';
+
+export const getNamesData = async (): Promise<NamesData> => {
+  const res = await fetch(`${I18NIFY_DATA_SOURCE}/names/data.json`);
+  if (!res.ok) {
+    throw new Error(`Failed to load names data: HTTP ${res.status}`);
+  }
+  return (await res.json()) as NamesData;
+};

--- a/packages/i18nify-js/src/modules/names/getHonorificTitles.ts
+++ b/packages/i18nify-js/src/modules/names/getHonorificTitles.ts
@@ -1,0 +1,64 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { HonorificTitle } from './types';
+import { getNamesData } from './data';
+
+/** Maps a BCP 47 base language subtag to the full English name used as the JSON key. */
+const LANG_CODE_TO_NAME: Record<string, string> = {
+  en: 'english',
+  hi: 'hindi',
+  fr: 'french',
+  de: 'german',
+  es: 'spanish',
+  ar: 'arabic',
+  ja: 'japanese',
+  zh: 'chinese',
+  pt: 'portuguese',
+  ru: 'russian',
+};
+
+/**
+ * Returns the list of honorific titles for the given BCP 47 base language tag.
+ *
+ * The locale is matched case-insensitively. If a full BCP 47 tag is supplied
+ * (e.g., "en-US"), only the base language subtag ("en") is used for lookup.
+ *
+ * @param {string} locale - BCP 47 base language tag (e.g., "en", "hi", "fr")
+ * @returns {Promise<HonorificTitle[]>} Array of honorific titles for the locale
+ *
+ * @throws {Error} When locale is empty or unsupported
+ *
+ * @example
+ * const titles = await getHonorificTitles('en');
+ * // [{ code: 'MR', title: 'Mr.', gender: 'male', description: '...' }, ...]
+ */
+const getHonorificTitles = async (
+  locale: string,
+): Promise<HonorificTitle[]> => {
+  const trimmed = (locale ?? '').trim();
+  if (!trimmed) {
+    throw new Error('locale must not be empty');
+  }
+
+  // Normalise: lowercase and extract base language subtag only.
+  const base = trimmed.toLowerCase().split('-')[0];
+
+  // Resolve BCP 47 code to the full language name used as the JSON key.
+  const langName = LANG_CODE_TO_NAME[base];
+  if (!langName) {
+    throw new Error(`No honorific titles found for locale: "${trimmed}"`);
+  }
+
+  const data = await getNamesData().catch((err) => {
+    throw new Error(
+      `An error occurred while fetching names data. The error details are: ${err.message}.`,
+    );
+  });
+
+  const titles = data.names_information.honorific_titles[langName];
+  if (!titles) {
+    throw new Error(`No honorific titles found for locale: "${trimmed}"`);
+  }
+  return titles;
+};
+
+export default withErrorBoundary<typeof getHonorificTitles>(getHonorificTitles);

--- a/packages/i18nify-js/src/modules/names/index.ts
+++ b/packages/i18nify-js/src/modules/names/index.ts
@@ -1,0 +1,3 @@
+export { default as isValidName } from './isValidName';
+export { default as getHonorificTitles } from './getHonorificTitles';
+export type { HonorificTitle, ValidationRules, NamesData } from './types';

--- a/packages/i18nify-js/src/modules/names/isValidName.ts
+++ b/packages/i18nify-js/src/modules/names/isValidName.ts
@@ -1,0 +1,42 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+
+/**
+ * Validates a personal name against i18nify name rules.
+ *
+ * A valid name must:
+ * - Be at least 2 characters long (after trimming whitespace).
+ * - Be at most 100 characters long.
+ * - Contain only Unicode letters, spaces, hyphens (-), apostrophes ('), or periods (.).
+ * - Contain at least one Unicode letter.
+ *
+ * @param {string} name - The name to validate
+ * @returns {boolean} True if the name is valid, false otherwise
+ *
+ * @example
+ * isValidName('John Smith');    // true
+ * isValidName("O'Brien");       // true
+ * isValidName('Mary-Jane');     // true
+ * isValidName('John2');         // false — digits not allowed
+ * isValidName('A');             // false — too short
+ */
+const isValidName = (name: string): boolean => {
+  const trimmed = (name ?? '').trim();
+
+  const MIN_LENGTH = 2;
+  const MAX_LENGTH = 100;
+
+  if (trimmed.length < MIN_LENGTH || trimmed.length > MAX_LENGTH) {
+    return false;
+  }
+
+  // Must contain at least one Unicode letter and only allowed characters.
+  // \p{M} includes combining marks (e.g., Devanagari vowel signs, Arabic diacritics)
+  // which are integral parts of correctly-spelled names in many scripts.
+  // Literal space is used (not \s) to exclude tabs and newlines.
+  const allowedPattern = /^[\p{L}\p{M} '\-.]+$/u;
+  const hasLetter = /\p{L}/u.test(trimmed);
+
+  return allowedPattern.test(trimmed) && hasLetter;
+};
+
+export default withErrorBoundary<typeof isValidName>(isValidName);

--- a/packages/i18nify-js/src/modules/names/types.ts
+++ b/packages/i18nify-js/src/modules/names/types.ts
@@ -1,0 +1,18 @@
+export interface HonorificTitle {
+  code: string;
+  title: string;
+  gender: 'male' | 'female' | 'neutral';
+  description: string;
+}
+
+export interface ValidationRules {
+  min_length: number;
+  max_length: number;
+}
+
+export interface NamesData {
+  names_information: {
+    honorific_titles: Record<string, HonorificTitle[]>;
+    validation_rules: ValidationRules;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `names` module with `isValidName(name)` and `getHonorificTitles(locale)`
- Unicode name validation (Devanagari, Arabic, CJK, hyphens, apostrophes); 2–100 chars
- Honorific titles for 10 locales with BCP 47 tag support
- Canonical data at `i18nify-data/names/data.json` and 32 tests

## Test plan

- [ ] Run: `yarn workspace @razorpay/i18nify-js test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)