### PR TITLE
chore(tooling): add utility-creator skill and Claude agents/commands

### DIFF
--- a/.claude/agents/fetcher.md
+++ b/.claude/agents/fetcher.md
@@ -1,0 +1,40 @@
+---
+name: i18nify-fetcher
+description: Fetches a single i18nify topic from its T1 source URL using Crawl4AI. Use this agent when you need to fetch raw data for one specific topic (currency, country, tld, etc.) without running the full pipeline.
+allowed-tools: Bash, Read, Write, mcp__crawl4ai__scrape, mcp__crawl4ai__crawl
+---
+
+You are a data fetcher for the i18nify project. Your job is to fetch one
+specific dataset from its authoritative T1 source and save the raw content.
+
+When invoked, you receive a topic name (e.g. `currency`, `tld`, `country`, `language`).
+
+## Your steps
+
+1. Look up the source URL in CLAUDE.md under "Topics and their T1 sources".
+
+2. Use the `crawl4ai` MCP tool to fetch the URL:
+   - **SPA pages** (`country`, ISO OBP language): set `wait_for="table tbody tr"` and include JS delay:
+     ```json
+     { "js_code": "await new Promise(r => setTimeout(r, 4000));" }
+     ```
+   - **Static files** (XML, JSON, YAML, plain text): fetch directly, no JS needed.
+
+3. Save raw content to `/tmp/i18nify_raw_{topic}.txt`
+
+4. Print one of:
+   - `RAW_SAVED|{topic}|{bytes}` — success
+   - `RAW_FAILED|{topic}|{error}` — failure with reason
+
+## Constraints
+- Never modify schemas or output files in `i18nify-data/` — only fetch and save raw content.
+- Never run `crawl4ai_runner.py` — the validator agent does that.
+- If Crawl4AI is not reachable (connection refused on port 11235), fall back to direct HTTP fetch:
+  ```bash
+  source venv/bin/activate && python3 -c "
+  import urllib.request
+  with urllib.request.urlopen('{url}', timeout=15) as r:
+      open('/tmp/i18nify_raw_{topic}.txt', 'wb').write(r.read())
+  print('RAW_SAVED|{topic}')
+  "
+  ```

--- a/.claude/agents/validator.md
+++ b/.claude/agents/validator.md
@@ -1,0 +1,46 @@
+---
+name: i18nify-validator
+description: Validates raw fetched i18nify data against Pydantic schemas and saves to i18nify-data/. Use after the i18nify-fetcher agent has saved raw content.
+allowed-tools: Bash, Read, Write
+---
+
+You are a data validator for the i18nify project. You receive raw fetched
+content (saved by the i18nify-fetcher agent) and validate it against the
+Pydantic schemas in `schemas/i18nify_schemas.py`.
+
+When invoked, you receive a topic name.
+
+## Your steps
+
+1. Confirm `/tmp/i18nify_raw_{topic}.txt` exists:
+   ```bash
+   ls -lh /tmp/i18nify_raw_{topic}.txt
+   ```
+
+2. Run the extraction and validation pipeline:
+   ```bash
+   source venv/bin/activate && python tools/crawlers/crawl4ai_runner.py \
+     --topic {topic} \
+     --input /tmp/i18nify_raw_{topic}.txt
+   ```
+
+3. Parse stdout for result tokens:
+   - `PARSE_OK|{topic}|{count}` → validation passed
+   - `PARSE_ERROR|{topic}|{reason}` → validation failed
+
+4. If `PARSE_ERROR`:
+   - Read the exact error message
+   - Check if the source format changed (new columns, renamed fields)
+   - Suggest a specific fix to `tools/crawlers/crawl4ai_runner.py` or the schema
+   - Do NOT make the fix yourself — report it clearly
+
+5. If `PARSE_OK`:
+   - Confirm files were written:
+     - `i18nify-data/{topic}/data.json`
+     - `i18nify_data/{topic}_pipeline.json` (with meta block)
+   - Print: `VALID_OK|{topic}|{count}`
+
+## Constraints
+- Never modify `i18nify-data/*/proto/` files.
+- Never modify schema files — only report mismatches.
+- Never run fetches — only validation.

--- a/.claude/commands/fetch-data.md
+++ b/.claude/commands/fetch-data.md
@@ -1,0 +1,51 @@
+---
+description: Fetch i18nify reference data for a given topic using Crawl4AI
+allowed-tools: Bash, Read, Write, mcp__crawl4ai__scrape, mcp__crawl4ai__crawl
+---
+
+# Fetch i18nify Data: $ARGUMENTS
+
+Fetch the reference dataset for topic: **$ARGUMENTS**
+
+## Steps
+
+1. Activate the Python virtual environment:
+```bash
+source venv/bin/activate
+```
+
+2. Check if fresh data already exists (< 30 days old):
+```bash
+python tools/crawlers/validate.py --check-age $ARGUMENTS
+```
+   If output is `FRESH`, skip to step 5.
+
+3. Use the `crawl4ai` MCP tool to fetch the source URL for this topic.
+   The URL mappings are in CLAUDE.md under "Topics and their T1 sources".
+
+   For SPA pages (`country`, `language` from ISO OBP):
+   ```json
+   {
+     "url": "<topic_url>",
+     "wait_for": "table tbody tr",
+     "js_code": "await new Promise(r => setTimeout(r, 4000));"
+   }
+   ```
+
+   For static XML / plain text / JSON / YAML: fetch directly without JS execution.
+
+4. Save the raw crawled content to `/tmp/i18nify_raw_$ARGUMENTS.txt`
+
+5. Run the extraction and validation pipeline:
+```bash
+python tools/crawlers/crawl4ai_runner.py --topic $ARGUMENTS --input /tmp/i18nify_raw_$ARGUMENTS.txt
+```
+
+6. If extraction fails or returns 0 rows:
+   - Check if the page structure changed (compare against known column names in the schema)
+   - Try a different extraction strategy (CSS selectors vs LLM extraction)
+   - Report the exact error with the FETCH_ERROR token
+
+7. Print final status:
+   - Success: `FETCH_OK|$ARGUMENTS|{row_count}`
+   - Failure: `FETCH_ERROR|$ARGUMENTS|{reason}`

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,20 @@
+---
+description: Show fetch status for all i18nify pipeline datasets
+allowed-tools: Bash, Read
+---
+
+# i18nify Data Pipeline Status
+
+Run this command and display the results as a table:
+
+```bash
+source venv/bin/activate && python tools/crawlers/validate.py --status
+```
+
+After showing the table:
+1. Highlight any datasets with status `STALE` or `MISSING`
+2. Suggest the command to refresh stale datasets:
+   ```
+   /fetch-data {topic}
+   ```
+3. Show total count of fresh vs stale vs missing topics.

--- a/.claude/skills/utility-creator/SKILL.md
+++ b/.claude/skills/utility-creator/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: utility-creator
+description: Use when asked to generate, scaffold, or create an i18nify utility module for a technical reference topic (currency, country, phone, address, TLD, language, HTTP status, MIME types, timezones, unicode blocks). Fetches authoritative data, scores sources, and writes JS/TS and Go module files directly to the repo.
+user-invocable: true
+allowed-tools:
+  - Bash(pip install *)
+  - Bash(python3 *)
+  - WebSearch
+  - WebFetch
+---
+
+# Utility Creator
+
+Fetch authoritative reference data, score it, and write complete i18nify JS/TS + Go module files directly to the repo. Output a single interactive widget and a scoring diagnostic, then scaffold the module if requested.
+
+## Agent quick start
+
+**Verify the pipeline works first** (takes ~5 s, uses `http_status_codes` as the probe topic):
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+bash .claude/skills/utility-creator/smoke.sh
+# → SMOKE_OK|http_status_codes|pipeline verified end-to-end
+```
+
+**Prerequisites** — venv must be present at repo root. Activate before any Recipe:
+
+```bash
+source venv/bin/activate   # required — crawl4ai_runner.py and PyMuPDF live here
+```
+
+**To run the skill** — follow Section 6 below. Start at Step 0 (clarification gate), then Step 1 (topic resolution), then Step 3 (Recipe 0 + Recipe 1).
+
+**Canonical data paths** — many topics' data files only exist after `crawl4ai_runner.py` has fetched them at least once. Recipe 1 checks local file age; on `CACHE_MISS` or `CACHE_STALE` it falls through to Recipe 3 which fetches and writes the file.
+
+**Docs navigation** — most content is split across four reference files. Read only the one you need:
+
+| Task | File |
+|---|---|
+| Find source URLs, tier rules, topic synonyms | [`docs/1_REGISTRY_AND_TIERS.md`](./docs/1_REGISTRY_AND_TIERS.md) |
+| Run any Recipe (0–8-Go), utility generation, unknown-topic research | [`docs/2_EXECUTION_RECIPES.md`](./docs/2_EXECUTION_RECIPES.md) |
+| Render the widget, scoring formula, conflict handling, diagnostics | [`docs/3_SCORING_AND_UI.md`](./docs/3_SCORING_AND_UI.md) |
+| Handle Recipe errors, Tracebacks, halt-and-display protocol | [`docs/4_ERROR_HANDLING.md`](./docs/4_ERROR_HANDLING.md) |
+
+## Trigger conditions
+
+Activate on phrases like: "find sources for", "get data links for", "find an API for", "give me links for", "best source for", "live data for", "fetch [technical topic]", or any request to retrieve structured technical reference data.
+
+Do NOT activate for: general programming help, debugging, opinion questions, non-technical reference data (food, sports, entertainment), or anything not backed by a standards body.
+
+## Phase 0 — Clarification Gate (runs before any data fetching)
+
+### Step 0-A: Internal assessment
+
+Before touching any Recipe, internally check the four parameters against the user's request:
+
+| Parameter | What to check | Example ambiguity |
+|---|---|---|
+| **Geographical scope** | Global, country-specific, or regional? | "phone codes" (global) vs "phone codes for Southeast Asia" (regional) |
+| **Domain/industry context** | General standard or niche-specific? | "address formats" (general) vs "address formats for healthcare billing" (niche) |
+| **Data type/granularity** | Dataset, API spec, compliance doc, whitepaper? | "tax data" is vague; "VAT regex patterns per EU country" is clear |
+| **Timeframe/version** | Latest, historical, or specific version? | "RFC" alone could mean any version |
+
+### Step 0-B: Act on the assessment
+
+**If ALL four parameters are clearly determined** (either stated explicitly or unambiguously implied by the topic — e.g., "ISO 4217 currency codes" implies global scope, dataset type, and current version):
+
+→ **Bypass clarification entirely.** Proceed directly to Section 6, Step 1.
+
+**If ANY parameter is missing AND matters for this topic:**
+
+→ **Ask only the specific missing question(s).** Halt all execution and wait for the user's reply. Do not begin Section 6 until the reply is received.
+
+**Example clarifying questions** (adapt phrasing to context, ask only what's actually unclear):
+- "To get you the right data — is this global or for a specific country/region?"
+- "Are you looking for raw datasets, API documentation, or regulatory/compliance guidelines?"
+- "Do you need the current standard or a specific historical version?"
+
+> **Rule:** Never ask about a parameter that is obviously implied by the topic. "Currency codes" is inherently global and dataset-typed — skip those questions entirely and proceed.
+
+### Step 0-C: Vague topic router (output format / depth gate)
+
+Before executing any Recipe, evaluate the user's prompt for **output intent**.
+
+If the user provides **only a broad topic** (e.g., *"India GST"*, *"Telecom codes"*) **without specifying** the desired output format or data depth, **DO NOT scrape the data yet.** Instead, halt execution and present the following clarification menu:
+
+---
+
+**Clarification Menu**
+
+I see you want to work with **[topic]**. To make sure I get you exactly what you need, how would you like me to process this?
+
+**1. Choose your depth:**
+- **[A]** High-level summaries (Broad categories, e.g. 2-digit chapter codes)
+- **[B]** Granular, specific line items (Exact data, e.g. 6-8 digit HSN codes)
+
+**2. Choose your output:**
+- **[1]** Fetch the raw data (JSON/CSV)
+- **[2]** Generate a data schema (Pydantic / TypeScript)
+- **[3]** Build a Python utility script to process this data
+- **[4]** Produce a Markdown summary report
+
+Please reply with your choices (e.g., *"B and 2"* or *"A, 1, and 3"*).
+
+---
+
+Once the user replies, map their choice to the pipeline parameters below and **only then** proceed to Section 6, Step 1.
+
+| User choice | Pipeline parameter |
+|---|---|
+| **A** (high-level) | `granularity="summary"` — broad regex patterns, chapter-level aggregates |
+| **B** (granular) | `granularity="item"` — exact line items, strict `^\d{6,8}$` filters |
+| **1** (raw data) | `output_mode="data"` — run full Recipes 0-7, emit widget |
+| **2** (schema) | `output_mode="schema"` — run Recipes 0-3, skip widget, emit Pydantic/TS |
+| **3** (utility) | `output_mode="utility"` — run Recipes 0-7 + Recipe 8, emit generated files |
+| **4** (report) | `output_mode="report"` — run Recipes 0-3, emit Markdown summary |
+
+> **Rule:** The clarification menu is a **single-shot gate**. Present it once. If the user ignores the menu and re-states a vague query, treat the second query as the same vague topic and re-present the menu. Never silently default to a granularity or output mode — that causes the 2-digit vs 8-digit data mismatch.
+
+## Core principle
+
+Source quality is guaranteed by the tier system — never recommend Tier 3 community sources when Tier 1 or Tier 2 exist. The output is exactly ONE thing: a live interactive widget. No sources tables, no API blocks, no JSON dumps in the response.
+
+## DATA PRECISION RULE — ENFORCED ON ALL PIPELINE OUTPUTS
+
+The pipeline must never output standalone shortcodes. Every shortcode must be
+accompanied by its full human-readable English name in the same object:
+
+| Shortcode field | Required companion field |
+|---|---|
+| `cc` (country code) | `country_name: str` |
+| `alpha2` / `alpha3` (language code) | `english: str` |
+| `languages: [str]` list | Must be `[{code, name}]` — never bare strings |
+| ISO 4217 `code` (currency) | `name: str` |
+
+This rule is enforced by `enrich_row()` in `tools/crawlers/crawl4ai_runner.py`
+and by the Pydantic schemas in `schemas/i18nify_schemas.py`. Any Recipe 8
+generated utility file will automatically reflect these enriched fields because
+it derives its data from the canonical `i18nify-data/{topic}/data.json` output.
+
+### MISSING FIELDS & ANTI-MORPHING
+
+If the authoritative source does not contain specific data fields the user explicitly requested, you must NEVER morph, fabricate, or guess the missing data to fulfill the prompt. You must output the widget using only the verified data the source actually provides.
+
+- **Do not** fill gaps by pulling columns from a Tier 3 community source.
+- **Do not** derive or infer a missing field from related fields (e.g., computing a calling code from a country name).
+- **Do not** silently omit the fact that requested fields are absent — surface the gap explicitly via the Missing Data Clarification Menu (Section 7, `docs/3_SCORING_AND_UI.md`).
+
+---
+
+## MANDATORY EXECUTION CONSTRAINT — READ BEFORE ANYTHING ELSE
+
+When this skill activates, the ONLY permitted way to fetch, parse, or score data is by running the numbered Recipes in Section 2-C via bash_tool, in the exact order defined in Section 6.
+
+**These actions are STRICTLY PROHIBITED once this skill activates for a KNOWN registered topic:**
+- Exploring GitHub repos manually (checking file structures, reading PHP source, grepping raw files)
+- Using web_search or web_fetch to **fetch or parse data** for a topic that is already in the registry (use Recipes instead — canonical domains may be blocked)
+- Writing ad-hoc curl, wget, or requests code outside of the Recipes
+- Attempting to parse or extract data from any file not written by a Recipe
+- Deciding a Recipe "won't work" and inventing an alternative approach
+- Skipping Recipe 0 (dependency install) before running any other Recipe
+- Proceeding past Step 3 without having run Recipe 0 and Recipe 1 first
+
+**Exception — unknown topics:** When a topic is NOT in the registry, web_search and web_fetch are the correct tools for source discovery. See Section 13 for the mandatory research protocol. The prohibition above applies only after a topic key has been matched in Section 2.
+
+If a Recipe fails or returns an unexpected output, follow the exact fallback path specified in Section 6 for that Recipe's output — do not invent a new approach.
+
+The Recipes exist precisely because canonical domains are blocked for known topics. Attempting to reach those domains via any other method will produce the same 403. Run the Recipes.
+
+---
+
+## Section 1 — Tier system
+
+> **AGENT INSTRUCTION:** The tier system has been moved. You MUST read [docs/1_REGISTRY_AND_TIERS.md](./docs/1_REGISTRY_AND_TIERS.md) for T1/T2/T3 definitions, classification criteria, and the Pragmatic Fallback Rule before selecting or rejecting any source.
+
+---
+
+## Section 2 — Source registry (topic → sources map)
+
+> **AGENT INSTRUCTION:** The source registry has been moved. You MUST read [docs/1_REGISTRY_AND_TIERS.md](./docs/1_REGISTRY_AND_TIERS.md) for the full topic → URL mapping (currency, country, TLD, phone, language, address, HTTP status, MIME, unicode, GST, and more) and synonym matching rules.
+
+---
+
+## Section 2-B — Pre-fetch cache resolver
+
+> **AGENT INSTRUCTION:** The pre-fetch cache resolver algorithm has been moved. You MUST read [docs/1_REGISTRY_AND_TIERS.md](./docs/1_REGISTRY_AND_TIERS.md) for the manifest URL, resolver algorithm, tier classification for cache hits, freshness scoring, and widget cache banner text.
+
+---
+
+## Section 2-C — Concrete execution recipes
+
+> **AGENT INSTRUCTION:** All numbered Recipes (0 through 8-Go) have been moved. You MUST read [docs/2_EXECUTION_RECIPES.md](./docs/2_EXECUTION_RECIPES.md) to execute any data retrieval. Do NOT attempt to write ad-hoc fetch code — copy the exact Recipe blocks from that file.
+
+---
+
+## Section 3 — Scoring model / Section 4 — Conflict handling / Section 5 — Performance
+
+> **AGENT INSTRUCTION:** The scoring formula, conflict detection rules, tie-breaking logic, and performance optimisations have been moved. Read [docs/3_SCORING_AND_UI.md](./docs/3_SCORING_AND_UI.md) when computing scores, handling conflicts, or applying TTL/freshness logic.
+
+---
+
+## Section 6 — Workflow
+
+**MANDATORY. Every step must be executed in order. Do not skip steps. Do not substitute ad-hoc code for a Recipe. If you have not run Recipe 0 yet, STOP and run it now before reading further.**
+
+Each step has a GATE — a condition that must be true before the next step begins. If the gate condition is not met, follow the specified fallback. Never proceed past a gate by assuming it passed.
+
+Step 0 — Clarification gate (Phase 0).
+  Run the Phase 0 assessment from the section above.
+  ── GATE: All four parameters are clear OR clarifying questions have been answered. ──
+  ── Do NOT proceed to Step 1 until this gate is met. ──
+
+Step 1 — Topic resolution.
+  Normalise query (lowercase, strip whitespace).
+  Match against synonyms in Section 2. This produces the canonical topic key
+  (e.g. "Swiss money" → "currency_codes", "address format" → "address_formats").
+  Unmatched → fall through to web search fallback queries from Section 2.
+  ── GATE: topic key is now defined. Substitute it as {TOPIC_KEY} in all Recipes. ──
+  ── Do NOT proceed to Step 2 until {TOPIC_KEY} is set. ──
+
+Step 2 — In-session cache check.
+  Hash the resolved topic key, check in-session memory.
+  GATE: Hit and not expired → return cached result immediately. STOP. Do not run any Recipe.
+  GATE: Miss or expired → continue to Step 3.
+
+Step 3 — MANDATORY: Run Recipe 0, then Recipe 1 via bash_tool.
+  ── STOP. Do not proceed until you have run Recipe 0 (pip install). ──
+  Run Section 2-C **Recipe 0** via bash_tool (installs deps). Run once per session.
+  Run Section 2-C **Recipe 1** via bash_tool. Substitute {TOPIC_KEY} literally.
+  Read stdout character by character. The first token on the line determines routing:
+    Starts with CACHE_HIT    → take the CACHE_HIT path below. Do NOT run Step 4.
+    Starts with CACHE_STALE  → continue to Step 4.
+    Starts with CACHE_MISS   → continue to Step 4.
+    Starts with CACHE_ERROR  → continue to Step 4. Do not surface the error.
+
+  CACHE_HIT path (skip Step 4 entirely):
+    Extract {CACHE_ENVELOPE_URL} from the CACHE_HIT line (second pipe-delimited field).
+    Run Section 2-C **Recipe 2** via bash_tool. Substitute {CACHE_ENVELOPE_URL}.
+    If Recipe 2 stdout contains ENVELOPE_OK → run Recipe 5. Go to Step 5.
+    If Recipe 2 stdout contains ENVELOPE_ERROR → fall through to Step 4 as CACHE_MISS.
+
+Step 4 — MANDATORY: Run Recipe 3 (Crawl4AI pipeline runner) via bash_tool.
+  ── STOP. You are here because Step 3 produced CACHE_STALE/MISS/ERROR. ──
+  ── Do NOT write ad-hoc fetch code. Do NOT use urllib/requests directly. Run Recipe 3. ──
+  Run Section 2-C **Recipe 3** via bash_tool. Substitute {TOPIC_KEY} literally.
+
+  Parse stdout for the terminal routing token:
+    Contains RUNNER_OK|{pipeline_topic}:
+      → crawl4ai_runner.py succeeded; canonical i18nify-data/{topic}/data.json is written.
+      → Re-run Recipe 1 with the same {TOPIC_KEY} — it MUST now return CACHE_HIT|LOCAL:...
+      → Extract {CACHE_ENVELOPE_URL} from the CACHE_HIT line.
+      → Run Recipe 2 with {CACHE_ENVELOPE_URL}. If ENVELOPE_OK → run Recipe 5. Go to Step 5.
+    Contains RUNNER_FAILED|...:
+      → The pipeline could not fetch or validate data.
+      → Return Section 8 "no trustable source" response.
+    Contains RUNNER_ERROR|... or non-zero exit or Traceback:
+      → Follow Section 11 halt-and-display rules immediately.
+  ── GATE: /tmp/tsf_parsed.json must exist after Recipe 5 completes (written via Step 5 path). ──
+
+Step 5 — Data is normalised.
+  ── GATE: /tmp/tsf_parsed.json must exist (written by Recipe 5). ──
+  ── If this file does not exist, something went wrong in Step 3 or 4 — do not continue. ──
+  Schema confirmed: array of {tier, name, url, via_mirror, columns, rows, source_type, from_cache}.
+
+Step 6 — MANDATORY: Run Recipe 6 via bash_tool.
+  ── STOP. Do not compute scores manually. Run Recipe 6. ──
+  Run Section 2-C **Recipe 6** via bash_tool. Substitute {TOPIC_KEY} literally.
+  Parse stdout:
+    MIXED_AGE_WARNING|... → set flag to add mixed-age banner in widget.
+    SCORE_DONE|...        → extract winner name, score, conflict_count, from_cache.
+  ── GATE: /tmp/tsf_result.json must exist after Recipe 6 completes. ──
+
+Step 7 — MANDATORY: Run Recipe 7 via bash_tool.
+  ── STOP. Do not read /tmp/tsf_result.json manually. Run Recipe 7. ──
+  Run Section 2-C **Recipe 7** via bash_tool.
+  Extract from stdout: topic, score, tier, source_name, source_url, rows, from_cache, conflict_count.
+
+Step 8 — Render the live widget (see Section 7).
+  Read /tmp/tsf_result.json for the full data to embed in the widget.
+  If from_cache=True → include the cache banner defined in Section 2-B.
+  If MIXED_AGE_WARNING was set → include the mixed-age warning.
+  If conflict_count > 0 → include the expandable conflict panel.
+
+Step 8.5 — Print scoring & diagnostics summary (see Section 9.5).
+  Immediately after the widget, read /tmp/tsf_result.json and print the
+  mandatory scoring diagnostic block defined in Section 9.5.
+
+Step 9 — In-session cache write.
+  Store result with topic-appropriate TTL from Section 5.
+  Cache key: hash(topic_key).
+
+---
+
+## Section 7 — Output contract & Widget HTML template
+
+> **AGENT INSTRUCTION:** The output contract, widget HTML template, scoring diagnostic bash snippet, and widget CSS/JS have been moved. Read [docs/3_SCORING_AND_UI.md](./docs/3_SCORING_AND_UI.md) to render the widget correctly (Section 7) and to print the scoring diagnostic after the widget (Section 9.5).
+
+---
+
+## Section 8 — When no trustable source exists
+
+> **AGENT INSTRUCTION:** The "no trustable source" response template has been moved. Read [docs/3_SCORING_AND_UI.md](./docs/3_SCORING_AND_UI.md) (Section 8) for the exact response structure to use when neither T1 nor T2 exists.
+
+---
+
+## Section 9 — Edge cases / Section 9.5 — Scoring & Diagnostics Summary
+
+> **AGENT INSTRUCTION:** Edge case handling rules and the scoring diagnostics summary bash snippet have been moved. Read [docs/3_SCORING_AND_UI.md](./docs/3_SCORING_AND_UI.md) (Sections 9 and 9.5).
+
+---
+
+## Section 10 — What this skill does NOT do / Section 11 — Error Transparency / Section 11.5 — Troubleshooting
+
+> **AGENT INSTRUCTION:** Error handling rules, the halt-and-display protocol, and the troubleshooting guide have been moved. Read [docs/4_ERROR_HANDLING.md](./docs/4_ERROR_HANDLING.md) whenever a Recipe returns an unexpected error token, non-zero exit, or Traceback.
+
+---
+
+## Section 12 — i18nify Utility Generation / Section 13 — Handling Unknown Topics
+
+> **AGENT INSTRUCTION:** Utility generation steps (Recipes 8 and 8-Go, barrel update, summary output) and the unknown-topic research protocol have been moved. Read [docs/2_EXECUTION_RECIPES.md](./docs/2_EXECUTION_RECIPES.md) (Sections 12 and 13) when the user requests utility scaffolding or when a topic is not in the registry.
+
+---
+
+## One-paragraph summary
+
+**For known topics, all data retrieval is done exclusively by running the numbered Recipes in Section 2-C via bash_tool in the order defined in Section 6. For unknown topics, web_search and web_fetch are used to hunt for authoritative T1/T2 sources before any Section 8 failure is declared (Section 13).** Resolve the query to a canonical topic key via synonym matching (Step 1), check in-session cache (Step 2), then run Recipe 0 (pip install, once) and Recipe 1 (check local canonical `i18nify-data/…/data.json` → remote manifest) via bash_tool — if CACHE_HIT, run Recipe 2 + Recipe 5 and skip live fetching entirely; if CACHE_STALE/MISS/ERROR, run Recipe 3 (Crawl4AI pipeline runner — delegates to `tools/crawlers/crawl4ai_runner.py`, which fetches from canonical T1 sources, validates, and writes `i18nify-data/{topic}/data.json`); on RUNNER_OK re-run Recipe 1 (now returns CACHE_HIT|LOCAL) → Recipe 2 → Recipe 5; on RUNNER_FAILED return Section 8. **Tier 2 sources are ONLY used as a fallback when the T1 source is paywalled, non-machine-readable, or completely inaccessible (Pragmatic Fallback Rule, Section 1).** Run Recipe 6 (conflict detection + Model B scoring, cache_freshness substitution when from_cache), Recipe 7 (extract winner), then render the single live widget with score breakdown, conflict panel, and cache banner (Step 8), then print the scoring diagnostic block from Section 9.5 (Step 8.5). Write to in-session cache (Step 9). Output the widget followed by the scoring diagnostic and nothing else. **When the user additionally requests utility generation**, execute Section 12 (Steps A–D): determine PROJECT_ROOT, run Recipe 8 (JS/TS files) then Recipe 8-Go (Go files) to write all i18nify utility files directly to the filesystem (no code echoed to terminal), update `src/index.ts` barrel with the Edit tool, and output a summary table of JS + Go files written. Section 11 governs error transparency across all Recipes — halt and display raw errors on any unexpected failure token.

--- a/.claude/skills/utility-creator/docs/1_REGISTRY_AND_TIERS.md
+++ b/.claude/skills/utility-creator/docs/1_REGISTRY_AND_TIERS.md
@@ -1,0 +1,309 @@
+# Technical Source Finder — Registry & Tiers
+
+This file is a supplement to the root [`SKILL.md`](../SKILL.md).
+It contains Section 1 (Tier system), Section 2 (Source registry), and Section 2-B (Pre-fetch cache resolver).
+
+---
+
+## Section 1 — Tier system
+
+### Tier 1 — Official (always prefer)
+
+Maintained directly by the standards body that owns the data. Authoritative by mandate.
+
+| Body | Domain | Owns |
+|---|---|---|
+| ITU | itu.int | Phone number formats, E.164 calling codes |
+| ISO | iso.org | Currency codes (ISO 4217), country codes (ISO 3166), language codes (ISO 639) |
+| IANA | iana.org | Timezone database, TLD / ccTLD list, IP allocations |
+| Unicode / CLDR | unicode.org | Currency display formats, number formatting, locale data |
+| SIX Group | six-group.com | ISO 4217 currency XML (delegated by ISO) |
+| Google i18n | chromium-i18n.appspot.com | Address formats per country |
+| W3C | w3.org | HTML, CSS, HTTP specs |
+| IETF | ietf.org, datatracker.ietf.org | Internet standards — RFC 5322, RFC 3339 etc |
+
+### Tier 2 — Official-derived (FALLBACK ONLY — use ONLY when T1 is inaccessible, paywalled, or non-machine-readable)
+
+Directly packages or mirrors Tier 1 data with clear citation chain. Actively maintained.
+
+**These sources are last-resort fallbacks. If a machine-readable T1 source exists for the topic, Tier 2 must be completely ignored and excluded from fetching. Never choose T2 for convenience.**
+
+| Source | Upstream | Packages |
+|---|---|---|
+| restcountries.com/v3.1 | ISO 3166 | Country name, codes, currencies, languages |
+| datahub.io/core/currency-codes | SIX Group / ISO 4217 | Currency codes, numeric codes, minor units |
+| datahub.io/core/top-level-domain-names | IANA Root Zone DB | All TLDs with type and sponsor |
+| datahub.io/core/language-codes | ISO 639 | Language codes and names |
+| unpkg.com/libphonenumber-js | ITU E.164 + Google | Example mobile numbers per country |
+| github.com/google/libphonenumber | ITU E.164 + Google | Full phone format patterns |
+| github.com/commerceguys/addressing | Google i18n Address Data | Address formats for 200+ countries — fallback if Google i18n appspot is inaccessible |
+| github.com/OpenCageData/address-formatting | Multiple postal authorities | Address templates per country — fallback if all T1 address sources are blocked |
+
+### Tier 3 — Community (NEVER USE)
+
+Random GitHub repos, gists, blog posts, npm packages without cited upstream. Excluded regardless of popularity. Star counts don't matter — provenance does.
+
+### Classification criteria
+
+| Criterion | T1 | T2 | T3 |
+|---|---|---|---|
+| Maintained by the standards body itself | yes | no | no |
+| Cites an upstream Tier 1 source | n/a | yes | no/unclear |
+| Actively maintained (last update <2yr) | usually | yes | varies |
+| Open to community edits without review | no | no | yes |
+
+Tier is per-topic, not per-domain. Wikipedia is T3 for ISO currency codes but arguably T2 for "list of UN member states" (UN itself updates the article). Always classify against the specific topic, not the domain.
+
+### Tier values used in scoring
+
+| Tier | Score |
+|---|---|
+| T1 (official) | 1.0 |
+| T2 (mirror, fresh) | 0.7 |
+| T2 (mirror, stale >2yr) | 0.5 |
+| T3 (rejected before scoring) | 0.3 |
+
+### Tier 1 scraping policy (strict)
+
+If a Tier 1 source exists for the topic, it MUST be scraped using the Crawl4AI runner (Recipe 3). Do NOT fall back to Tier 2 mirrors for convenience.
+
+**Pragmatic Fallback Rule — Tier 2 sources may ONLY be used if the Tier 1 source is completely inaccessible, paywalled (like ITU), or non-machine-readable. If a machine-readable Tier 1 source exists, Tier 2 must be completely ignored and excluded from fetching.**
+
+- **T1 accessible and machine-readable** → use Recipe 3 to scrape it directly. Tier 2 is excluded entirely.
+- **T1 is a PDF, paywalled, or non-machine-readable** → Tier 2 fallback is permitted. Use the best Tier 2 source listed in Section 2 for that topic. Note the fallback in the widget.
+- **T1 not found for this topic** → route to Section 8 response.
+
+Tier 2 mirrors are listed in Section 2. They are ONLY consulted as a last resort when the Pragmatic Fallback conditions above are met.
+
+---
+
+## Section 2 — Source registry (topic → sources map)
+
+Pre-computed mapping for the top topics. When a query matches one of these, skip web search and go directly to fetching. Match queries against synonyms with lowercase substring matching.
+
+### currency_codes
+Synonyms: `iso 4217`, `currency codes`, `currency list`, `world currencies`, `currency symbols`
+- T1: SIX Group XML — `https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml`
+- T1: Unicode CLDR currency names — `https://raw.githubusercontent.com/unicode-org/cldr-json/main/cldr-json/cldr-numbers-full/main/en/currencies.json`
+- T1: Unicode CLDR currency fractions — `https://raw.githubusercontent.com/unicode-org/cldr-json/main/cldr-json/cldr-core/supplemental/currencyData.json`
+- Expected coverage: ~180 active codes
+
+### country_codes
+Synonyms: `iso 3166`, `country codes`, `country list`, `cca2`, `cca3`
+- T1: ISO OBP SPA — `https://www.iso.org/obp/ui/#search/code/` (requires Crawl4AI; see crawl4ai_runner.py `fetch_country_iso_obp()`)
+- Expected coverage: 249 countries
+
+### timezones
+Synonyms: `iana timezones`, `timezone list`, `tz database`, `time zones`
+- T1: IANA tzdata zone1970.tab — `https://raw.githubusercontent.com/eggert/tz/main/zone1970.tab`
+- Expected coverage: 600+ identifiers
+
+### phone_calling_codes
+Synonyms: `phone codes`, `calling codes`, `country dial codes`, `e.164`, `phone country code`
+- T1: ITU E.164 — `https://www.itu.int/pub/T-SP-E.164D` (PDF/paywalled — no machine-readable T1 exists)
+- T1-derived fallback: Google i18n libphonenumber metadata — `https://raw.githubusercontent.com/google/libphonenumber/master/resources/PhoneNumberMetadata.xml` (published and maintained by Google i18n team; accepted as T1-derived under strict policy)
+  - **Fallback condition met**: ITU T1 is paywalled and non-machine-readable → T1-derived fallback is permitted per the Pragmatic Fallback Rule.
+- T2 fallback (last resort only): `unpkg.com/libphonenumber-js` or `datahub.io/core/language-codes` — only if libphonenumber XML is also inaccessible.
+- Note: ITU E.164 is not machine-readable. Use `--input` mode with a manually downloaded ITU document, or use the Google i18n libphonenumber XML which is the authoritative T1-derived source.
+- Expected coverage: 240 country codes
+
+### tld_list
+Synonyms: `tld`, `tlds`, `top level domains`, `cctld`, `domain extensions`
+- T1: IANA TLD list — `https://data.iana.org/TLD/tlds-alpha-by-domain.txt`
+- Expected coverage: 1500+ TLDs
+
+### language_codes
+Synonyms: `iso 639`, `language codes`, `language list`, `locale codes`
+- T1: Unicode CLDR territoryInfo — `https://raw.githubusercontent.com/unicode-org/cldr-json/main/cldr-json/cldr-core/supplemental/territoryInfo.json`
+  - Note: keyed by ISO 3166-1 alpha-2 country code → official ISO 639-1 language codes (country-to-languages mapping)
+- Expected coverage: 249 countries
+
+
+### address_formats
+Synonyms: `address format`, `postal address`, `country address`, `address per country`
+- T1: Google i18n — `https://chromium-i18n.appspot.com/ssl-address/data` (root endpoint enumerates all countries; per-country: `…/data/{CC}`)
+  - Note: dynamic multi-page JSON API; see crawl4ai_runner.py `fetch_address_google_i18n()` for batch scrape implementation
+- T2 fallback (last resort only): `github.com/OpenCageData/address-formatting` YAML — only if Google i18n appspot is completely inaccessible or returns no data. **Do NOT use as primary source.**
+- Expected coverage: 240+ countries
+
+### postal_codes
+Synonyms: `postal codes`, `zip codes`, `postcode format`
+- T1: UPU — paywalled, not machine-readable. No accessible T1 source exists → Section 8 response.
+
+### currency_display
+Synonyms: `currency format`, `currency symbol`, `currency display`, `cldr currency`
+- T1: CLDR JSON — `https://raw.githubusercontent.com/unicode-org/cldr-json/main/cldr-json/cldr-numbers-modern/main/en/numbers.json`
+- Expected coverage: 700+ locales
+
+### http_status_codes
+Synonyms: `http status`, `http codes`, `status codes`, `rfc 9110`
+- T1: IANA registry — `https://www.iana.org/assignments/http-status-codes/http-status-codes.xml`
+  - github_mirror: none (IANA XML; use pre-fetch pipeline)
+- Expected coverage: 60+ codes
+
+### mime_types
+Synonyms: `mime types`, `media types`, `content types`, `iana media types`
+- T1: IANA — `https://www.iana.org/assignments/media-types/media-types.xml`
+- Expected coverage: 2000+ types
+
+### unicode_blocks
+Synonyms: `unicode blocks`, `unicode ranges`, `unicode characters`
+- T1: Unicode.org — `https://www.unicode.org/Public/UNIDATA/Blocks.txt`
+
+### iban_formats
+Synonyms: `iban`, `iban format`, `bank account format`
+- T1: SWIFT IBAN registry — `https://www.swift.com/standards/data-standards/iban`
+
+### email_syntax
+Synonyms: `email format`, `email syntax`, `rfc 5322`, `email validation`
+- T1: RFC 5322 — `https://datatracker.ietf.org/doc/html/rfc5322`
+
+### gst_rates_india
+Synonyms: `india gst`, `gst rates`, `hsn code gst`, `gst india`, `gstin tax`, `indian tax rates`, `hsn chapter rates`, `sac gst`, `gst percentage india`
+- T1: CBIC chapter-wise rate schedule PDF — `https://cbic-gst.gov.in/pdf/chapter-wise-rate-wise-gst-schedule-18.05.2017.pdf`
+  - Official PDF published by CBIC (Central Board of Indirect Taxes and Customs) listing all HSN chapters with applicable GST rates (Nil / 5% / 12% / 18% / 28%).
+  - Columns: S.No. | Chapter | Nil | 5% | 12% | 18% | 28%
+  - Use `crawl4ai_runner.py --topic gst` which downloads the PDF directly via `fetch_gst_india()` and parses it with `parse_gst_india()` using PyMuPDF.
+  - Requires `PyMuPDF` (`pip install PyMuPDF`) in the venv.
+  - Landing page (for Referer header): `https://cbic-gst.gov.in/gst-goods-services-rates.html`
+- Expected coverage: ~81 HSN chapters (2017 base schedule; chapters with highly heterogeneous sub-heading rates show "Varies")
+- Note: The CBIC HSN/SAC search API (`https://services.gst.gov.in/services/searchhsnsac`) was previously used but is rate-limited and does not expose chapter-level rate breakdowns. The PDF is the primary T1 source.
+
+### population_data
+Synonyms: `population`, `pop`, `world population`, `population counts`, `population growth`, `population by country`
+- T1: UN World Population Prospects 2024 (gzip'd CSV) — `https://population.un.org/wpp/Download/Files/1_Indicator%20(Standard)/CSV_FILES/WPP2024_TotalPopulationBySex.csv.gz`
+- T1 fallback: World Bank Open Data API (SP.POP.TOTL + SP.POP.GROW) — `https://api.worldbank.org/v2/country/all/indicator/SP.POP.TOTL?format=json&mrv=1&per_page=300`
+  - **Fallback condition**: UN WPP gzip may be blocked by Cloudflare or have temporary download issues.
+  - Growth rate fetched from a second endpoint: `https://api.worldbank.org/v2/country/all/indicator/SP.POP.GROW?format=json&mrv=1&per_page=300`
+- Expected coverage: ~217 sovereign countries (ISO 3166-1 alpha-2)
+- TTL: 365 days (annual release cadence)
+
+### Unknown topic — research hunt
+
+If the query doesn't match any known topic, the registry is not your ceiling — it is just a cache of previously solved topics. Activate the **Section 13 research protocol**:
+
+1. Run targeted web searches to find the official T1/T2 source
+2. Classify every result against the tier criteria (discard T3 immediately)
+3. If a valid source is found → produce a Section 13 registry-addition proposal
+4. Only if exhaustive searching yields nothing → route to Section 8 "no trustable source" response
+
+Do NOT route to Section 8 until Section 13 has been fully executed.
+
+---
+
+## Section 2-B — Pre-fetch cache resolver
+
+### Purpose
+
+Corporate sandbox policies block many T1/T2 canonical domains at the network
+egress layer (not CORS — a proxy-level 403 before the request reaches the
+target server). A companion pipeline (`prefetch.py`) runs outside the sandbox
+on an unrestricted machine, fetches those sources, and pushes normalised JSON
+to a GitHub repo you own. Because `raw.githubusercontent.com` is on the
+sandbox allowlist, the skill can always read back from that repo.
+
+### Configuration
+
+Set these two values once when deploying the skill:
+
+```
+PREFETCH_REPO   = "razorpay/i18nify"      # GitHub repo owner/name
+PREFETCH_BRANCH = "master"                 # branch where pipeline pushes data
+```
+
+Manifest URL:
+```
+https://raw.githubusercontent.com/{PREFETCH_REPO}/{PREFETCH_BRANCH}/data/manifest.json
+```
+
+### Resolver algorithm (runs as Step 3 in Section 6, after topic is resolved)
+
+PRECONDITION: canonical topic key is already known from Step 1.
+(e.g. "Swiss money" → "currency_codes" via synonym matching in Step 1)
+
+```
+Step 3 — Pre-fetch cache resolver
+
+  a. Fetch manifest.json from the GitHub cache repo (10s timeout).
+     URL: https://raw.githubusercontent.com/{PREFETCH_REPO}/{PREFETCH_BRANCH}/data/manifest.json
+
+  b. Parse manifest. Look up manifest.topics[topic]:
+
+     if topic entry exists AND manifest.topics[topic].ok == true:
+       cache_url  = manifest.topics[topic].raw_url
+       cache_age  = (now − manifest.generated) in days   ← ISO timestamp diff
+       topic_ttl  = TTL from Section 5 TTL table (e.g. 30d for currency_codes)
+
+       if cache_age <= topic_ttl:
+         ── CACHE HIT ──
+         Fetch cache_url (raw JSON envelope). 10s timeout.
+         Extract sources from envelope.sources[].
+         For each source entry:
+           tier       ← envelope.sources[n].meta.tier
+           url_used   ← envelope.sources[n].meta.url_used
+           via_github ← envelope.sources[n].meta.via_github
+           data       ← envelope.sources[n].data
+         Skip Step 4 (live fetch).
+         Proceed to Step 5 (normalise) using this data.
+
+       else:
+         ── CACHE STALE ──
+         Log internally: "cache stale (age={cache_age}d > ttl={topic_ttl}d)"
+         Fall through to Step 4 (live fetch attempt).
+
+     else:
+       ── CACHE MISS ──
+       topic not in manifest or ok=false
+       Fall through to Step 4 (live fetch attempt).
+
+  c. If manifest.json itself fails to fetch (timeout, 404, parse error):
+     Fall through to Step 4 (live fetch attempt).
+     Do NOT abort — pipeline may not be deployed yet.
+     Do NOT surface this error to the user.
+```
+
+### Tier classification for cache hits
+
+Cache data inherits the tier of its **original source**, not the GitHub
+delivery URL. GitHub is a delivery mechanism, not a data authority.
+
+```
+envelope.sources[n].meta.tier == 1  →  treat as T1 in scoring
+envelope.sources[n].meta.tier == 2  →  treat as T2 in scoring
+```
+
+Always display the original canonical source URL in the widget, with a note
+that data was served from cache. Never show the GitHub cache URL as the source.
+
+### Freshness score for cache hits
+
+Apply a linear decay multiplier so a just-refreshed cache scores identically
+to a live fetch, and a cache at TTL boundary scores 0.5× freshness:
+
+```python
+cache_freshness = max(0.5, 1.0 - (cache_age_days / topic_ttl_days) * 0.5)
+```
+
+Substitute this value for the `freshness` factor in the Section 3 formula.
+
+### Conflict detection with mixed-age cache entries
+
+If two sources in the same envelope have `fetched_at` timestamps more than
+7 days apart, add a widget warning:
+
+```
+"Conflict detection may be unreliable — cache sources have different fetch
+timestamps (delta: {days}d). Re-run: python prefetch.py --topics {topic} --push"
+```
+
+### Widget note when serving from cache
+
+Add this to the amber info banner in the widget:
+
+```
+Pre-fetched data · cached {cache_age_human} ago
+Original source: {canonical_url}  (blocked by sandbox policy)
+Refresh: python prefetch.py --push --topics {topic}
+```
+
+---

--- a/.claude/skills/utility-creator/docs/2_EXECUTION_RECIPES.md
+++ b/.claude/skills/utility-creator/docs/2_EXECUTION_RECIPES.md
@@ -1,0 +1,1429 @@
+# Technical Source Finder — Execution Recipes
+
+This file is a supplement to the root [`SKILL.md`](../SKILL.md).
+It contains Section 2-C (all numbered Recipes), Section 12 (i18nify Utility Generation), and Section 13 (Handling Unknown Topics).
+
+---
+
+## Section 2-C — Concrete execution recipes
+
+**These Recipes are the ONLY permitted method for data retrieval in this skill.**
+**Do not write curl, wget, or requests code outside these Recipes.**
+**Do not explore repos, read source files, or use web_fetch/web_search to retrieve data.**
+**Copy each Recipe block exactly into bash_tool. Substitute only the {PLACEHOLDER} values.**
+
+Recipe execution order is enforced by Section 6. Never run a Recipe out of order.
+
+---
+
+---
+
+### Recipe 0 — Setup (run once per session before anything else)
+
+```bash
+pip3 install requests pyyaml lxml -q 2>&1 | tail -3
+```
+
+---
+
+### Recipe 1 — Check local canonical cache, then remote manifest
+
+Run this at Step 3. Checks `i18nify-data/{topic}/data.json` (the canonical
+output written by `crawl4ai_runner.py`) on the local filesystem first. Falls
+back to the remote GitHub manifest only when no local file exists.
+
+Uses `os.path.getmtime()` on the canonical file for cache-age calculation — no
+metadata block required.
+
+Replace `{TOPIC_KEY}` with the resolved topic key from Step 1.
+Replace `{PREFETCH_REPO}` and `{PREFETCH_BRANCH}` with configured values.
+
+```bash
+python3 << 'EOF'
+import os, sys, urllib.request, json
+from datetime import datetime, timezone
+
+topic = "{TOPIC_KEY}"
+
+# Map TSF topic keys → canonical i18nify-data file paths (mirrors DATA_PATH_MAP in schemas)
+# NOTE: these files only exist after crawl4ai_runner.py has fetched + validated the topic
+# at least once. If missing, Recipe 1 returns CACHE_MISS and Recipe 3 fetches + writes them.
+# Verified present (as of last pipeline run): tld_list, http_status_codes, language_codes,
+#   phone_calling_codes, unicode_blocks, address_formats.
+# Not yet fetched (will CACHE_MISS → Recipe 3): currency_codes, country_codes, timezones,
+#   mime_types, gst_rates_india.
+CANONICAL_PATH = {
+    "currency_codes":      "i18nify-data/currency/data.json",
+    "country_codes":       "i18nify-data/country/metadata/data.json",
+    "tld_list":            "i18nify-data/tld/data.json",
+    "http_status_codes":   "i18nify-data/http-status/data.json",
+    "language_codes":      "i18nify-data/language/data.json",
+    "phone_calling_codes": "i18nify-data/phone-number/data.json",
+    "timezones":           "i18nify-data/timezone/data.json",
+    "mime_types":          "i18nify-data/media/data.json",
+    "unicode_blocks":      "i18nify-data/unicode-blocks/data.json",
+    "address_formats":     "i18nify-data/address/data.json",
+    "gst_rates_india":     "i18nify-data/gst/data.json",
+    "population_data":     "i18nify-data/population/data.json",
+}
+
+ttl_map = {
+    "currency_codes":30,"country_codes":30,"address_formats":30,
+    "tld_list":7,"language_codes":30,"http_status_codes":7,
+    "phone_calling_codes":30,"timezones":7,"mime_types":30,
+    "unicode_blocks":30,"gst_rates_india":30,"population_data":365,
+}
+ttl = ttl_map.get(topic, 30)
+
+# 1. Check local canonical file first (age derived from mtime)
+local_path = CANONICAL_PATH.get(topic)
+if local_path and os.path.exists(local_path):
+    try:
+        mtime = os.path.getmtime(local_path)
+        age_days = (datetime.now(timezone.utc).timestamp() - mtime) / 86400
+        if age_days <= ttl:
+            print(f"CACHE_HIT|LOCAL:{local_path}|{age_days:.1f}|{ttl}")
+        else:
+            print(f"CACHE_STALE|{age_days:.1f}|{ttl}")
+        sys.exit(0)
+    except Exception:
+        pass  # cannot stat file → fall through to remote
+
+# 2. Fallback: remote GitHub manifest
+url = "https://raw.githubusercontent.com/{PREFETCH_REPO}/{PREFETCH_BRANCH}/data/manifest.json"
+try:
+    with urllib.request.urlopen(url, timeout=5) as r:
+        manifest = json.loads(r.read())
+    entry = manifest.get("topics", {}).get(topic)
+    if not entry or not entry.get("ok"):
+        print("CACHE_MISS")
+        sys.exit(0)
+    generated = datetime.fromisoformat(manifest["generated"])
+    age_days = (datetime.now(timezone.utc) - generated).total_seconds() / 86400
+    if age_days <= ttl:
+        print(f"CACHE_HIT|REMOTE:{entry['raw_url']}|{age_days:.1f}|{ttl}")
+    else:
+        print(f"CACHE_STALE|{age_days:.1f}|{ttl}")
+except Exception as e:
+    print(f"CACHE_ERROR|{e}")
+EOF
+```
+
+**Parse the output:**
+- `CACHE_HIT|LOCAL:{path}|{age}|{ttl}` → proceed to Recipe 2 with that path
+- `CACHE_HIT|REMOTE:{url}|{age}|{ttl}` → proceed to Recipe 2 with that URL
+- `CACHE_STALE|...` → proceed to Recipe 3 (crawl4ai runner)
+- `CACHE_MISS` → proceed to Recipe 3 (crawl4ai runner)
+- `CACHE_ERROR|...` → proceed to Recipe 3 (crawl4ai runner), do not surface error to user
+
+---
+
+### Recipe 2 — Load data from cache (local canonical or remote envelope)
+
+Run this when Recipe 1 returns `CACHE_HIT`. The `{CACHE_ENVELOPE_URL}` value
+is the second pipe-delimited field from the `CACHE_HIT` line — it starts with
+either `LOCAL:` (canonical `i18nify-data/…/data.json`) or `REMOTE:` (GitHub
+envelope URL).
+
+Local canonical files are written by `crawl4ai_runner.py` and have the
+structure `{data_key: {id: {...}, ...}}`. This recipe loads them, reconstructs
+a flat row list (`cc` key added back), derives `fetched_at` from mtime, and
+wraps everything into the `sources` envelope that Recipe 5 expects.
+
+```bash
+python3 << 'EOF'
+import urllib.request, json, sys, os
+from datetime import datetime, timezone
+
+hit_path = "{CACHE_ENVELOPE_URL}"   # from Recipe 1 CACHE_HIT output
+
+# Maps canonical file path → root data_key (mirrors DATA_KEY_MAP in schemas)
+PATH_DATA_KEY = {
+    "i18nify-data/currency/data.json":          "currency_information",
+    "i18nify-data/country/metadata/data.json":  "country_information",
+    "i18nify-data/tld/data.json":               "tld_information",
+    "i18nify-data/http-status/data.json":       "http_status_information",
+    "i18nify-data/language/data.json":          "language_information",
+    "i18nify-data/phone-number/data.json":      "country_tele_information",
+    "i18nify-data/timezone/data.json":          "timezone_information",
+    "i18nify-data/media/data.json":             "mime_type_information",
+    "i18nify-data/unicode-blocks/data.json":    "unicode_block_information",
+    "i18nify-data/address/data.json":           "address_format_information",
+    "i18nify-data/population/data.json":        "population_information",
+}
+
+# Maps canonical file path → T1 source URL for display in the widget
+PATH_SOURCE_URL = {
+    "i18nify-data/currency/data.json":          "https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml",
+    "i18nify-data/country/metadata/data.json":  "https://www.iso.org/obp/ui/#search/code/",
+    "i18nify-data/tld/data.json":               "https://data.iana.org/TLD/tlds-alpha-by-domain.txt",
+    "i18nify-data/http-status/data.json":       "https://www.iana.org/assignments/http-status-codes/http-status-codes.xml",
+    "i18nify-data/language/data.json":          "https://raw.githubusercontent.com/unicode-org/cldr-json/main/cldr-json/cldr-core/supplemental/territoryInfo.json",
+    "i18nify-data/phone-number/data.json":      "https://raw.githubusercontent.com/google/libphonenumber/master/resources/PhoneNumberMetadata.xml",
+    "i18nify-data/timezone/data.json":          "https://raw.githubusercontent.com/eggert/tz/main/zone1970.tab",
+    "i18nify-data/media/data.json":             "https://www.iana.org/assignments/media-types/media-types.xml",
+    "i18nify-data/unicode-blocks/data.json":    "https://www.unicode.org/Public/UNIDATA/Blocks.txt",
+    "i18nify-data/address/data.json":           "https://chromium-i18n.appspot.com/ssl-address/data",
+    "i18nify-data/population/data.json":        "https://api.worldbank.org/v2/country/all/indicator/SP.POP.TOTL?format=json&mrv=1&per_page=300",
+}
+
+try:
+    if hit_path.startswith("LOCAL:"):
+        file_path = hit_path[len("LOCAL:"):]
+        # Derive fetched_at from file mtime (canonical files have no meta block)
+        mtime = os.path.getmtime(file_path)
+        fetched_at = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+
+        data_key   = PATH_DATA_KEY.get(file_path, "")
+        source_url = PATH_SOURCE_URL.get(file_path, "local")
+
+        with open(file_path) as f:
+            canonical = json.load(f)
+
+        # canonical structure: {data_key: {id: {...}, ...}}
+        data_dict = canonical.get(data_key) if data_key else None
+        if not data_dict:
+            # fallback: use first top-level value
+            data_dict = next(iter(canonical.values()), {})
+
+        # Reconstruct flat row list with the dict key added back as "cc"
+        data = [{"cc": k, **v} for k, v in data_dict.items()] if isinstance(data_dict, dict) else []
+
+        envelope = {
+            "sources": [{
+                "meta": {
+                    "tier":        1,
+                    "source_name": source_url,
+                    "url_used":    source_url,
+                    "fetched_at":  fetched_at,
+                    "via_github":  False,
+                },
+                "data": data,
+            }]
+        }
+    else:
+        url = hit_path[len("REMOTE:"):] if hit_path.startswith("REMOTE:") else hit_path
+        with urllib.request.urlopen(url, timeout=10) as r:
+            envelope = json.loads(r.read())
+
+    # Emit compact summary for scoring
+    for i, src in enumerate(envelope.get("sources", [])):
+        m = src["meta"]
+        print(f"SOURCE|{i}|tier={m['tier']}|name={m['source_name']}"
+              f"|url={m['url_used']}|fetched={m['fetched_at']}"
+              f"|via_github={m['via_github']}")
+
+    # Write normalised envelope for Recipe 5
+    with open("/tmp/tsf_cache_data.json", "w") as f:
+        json.dump(envelope, f, ensure_ascii=False)
+    print("ENVELOPE_OK")
+except Exception as e:
+    print(f"ENVELOPE_ERROR|{e}")
+EOF
+```
+
+**Parse the output:**
+- Lines starting with `SOURCE|` → extract tier, name, url, fetched_at for scoring
+- `ENVELOPE_OK` → proceed to Recipe 5 using `/tmp/tsf_cache_data.json`
+- `ENVELOPE_ERROR|...` → fall through to Recipe 3 (crawl4ai runner)
+
+---
+
+### Recipe 3 — Crawl4AI pipeline runner
+
+Run this when Recipe 1 returns CACHE_STALE, CACHE_MISS, or CACHE_ERROR.
+Delegates to `tools/crawlers/crawl4ai_runner.py` which fetches from T1
+canonical sources, validates against Pydantic schemas, and writes the
+canonical output to `i18nify-data/{topic}/data.json`.
+
+On success the cache is immediately populated, so a re-run of Recipe 1 will
+return `CACHE_HIT|LOCAL:...` — no separate parse step required.
+
+Replace `{TOPIC_KEY}` with the resolved topic key from Step 1.
+
+```bash
+python3 << 'EOF'
+import subprocess, sys, os
+
+# Map TSF topic keys → crawl4ai_runner --topic argument
+PIPELINE_NAME = {
+    "currency_codes":      "currency",
+    "country_codes":       "country",
+    "tld_list":            "tld",
+    "http_status_codes":   "http_status",
+    "language_codes":      "language",
+    "phone_calling_codes": "phone",
+    "timezones":           "timezone",
+    "mime_types":          "mime",
+    "unicode_blocks":      "unicode_blocks",
+    "address_formats":     "address",
+    "gst_rates_india":     "gst",
+    "population_data":     "population",
+}
+
+tsf_topic     = "{TOPIC_KEY}"
+pipeline_topic = PIPELINE_NAME.get(tsf_topic)
+
+if not pipeline_topic:
+    print(f"RUNNER_ERROR|no pipeline mapping for TSF topic: {tsf_topic!r}")
+    sys.exit(1)
+
+# Resolve repo root so the runner's relative paths work correctly
+root_result = subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"],
+    capture_output=True, text=True,
+)
+repo_root = root_result.stdout.strip()
+if not repo_root:
+    print("RUNNER_ERROR|could not determine repo root via git")
+    sys.exit(1)
+
+runner   = os.path.join(repo_root, "tools", "crawlers", "crawl4ai_runner.py")
+venv_py  = os.path.join(repo_root, "venv", "bin", "python")
+python   = venv_py if os.path.exists(venv_py) else sys.executable
+
+proc = subprocess.run(
+    [python, runner, "--topic", pipeline_topic],
+    cwd=repo_root,
+    capture_output=True,
+    text=True,
+)
+
+# Stream output for visibility
+print(proc.stdout, end="")
+if proc.stderr:
+    print(proc.stderr, end="", file=sys.stderr)
+
+if proc.returncode != 0 or "FETCH_ERROR" in proc.stdout or "PARSE_ERROR" in proc.stdout:
+    print(f"RUNNER_FAILED|{pipeline_topic}|exit={proc.returncode}")
+    sys.exit(1)
+
+if "PARSE_OK" in proc.stdout:
+    print(f"RUNNER_OK|{pipeline_topic}")
+else:
+    print(f"RUNNER_FAILED|{pipeline_topic}|no PARSE_OK in output")
+    sys.exit(1)
+EOF
+```
+
+**Parse the output:**
+- `RUNNER_OK|{pipeline_topic}` → runner wrote `i18nify-data/{canonical_path}`; re-run Recipe 1 to get `CACHE_HIT|LOCAL`
+- `RUNNER_FAILED|...` → runner could not fetch or validate; proceed to Section 8
+- `RUNNER_ERROR|...` or non-zero exit or Traceback → follow Section 11 halt-and-display rules
+
+---
+
+### Recipe 4 — (removed)
+
+Recipe 4 was a standalone live-fetch recipe that predated the `crawl4ai_runner.py` pipeline.
+It was merged into Recipe 3. The numbering gap is preserved intentionally so that references
+in commit history and issue comments remain valid. Recipe 3 now covers what both 3 and 4 did.
+
+---
+
+### Recipe 5 — Load and normalise cache envelope data
+
+Run this after Recipe 2 succeeds (cache hit path). Normalises the cache envelope into `/tmp/tsf_parsed.json` for Recipe 6.
+
+```bash
+python3 << 'EOF'
+import json
+
+with open("/tmp/tsf_cache_data.json") as f:
+    envelope = json.load(f)
+
+parsed = []
+for i, src in enumerate(envelope.get("sources", [])):
+    m   = src["meta"]
+    raw = src["data"]
+    # data is already normalised by prefetch.py — wrap into common schema
+    if isinstance(raw, list):
+        cols = list(raw[0].keys()) if raw else []
+        rows = raw
+    elif isinstance(raw, dict):
+        # e.g. CLDR names dict → flatten to rows
+        rows = [{"code":k, **v} if isinstance(v,dict) else {"code":k,"value":v}
+                for k,v in raw.items()]
+        cols = list(rows[0].keys()) if rows else []
+    else:
+        rows, cols = [], []
+    parsed.append({
+        "tier":        m["tier"],
+        "name":        m["source_name"],
+        "url":         m["url_used"],
+        "via_mirror":  m["via_github"],
+        "fetched_at":  m["fetched_at"],
+        "columns":     cols,
+        "rows":        rows,
+        "source_type": "prefetch_cache",
+        "from_cache":  True,
+    })
+    print(f"CACHE_SRC_OK|{i}|tier={m['tier']}|rows={len(rows)}|name={m['source_name']}")
+
+with open("/tmp/tsf_parsed.json","w") as f:
+    json.dump(parsed, f, ensure_ascii=False)
+print(f"CACHE_LOAD_DONE|{len(parsed)}")
+EOF
+```
+
+---
+
+### Recipe 6 — Conflict detection and score computation
+
+Run this after Recipe 5. Works identically for live and cached data.
+
+```bash
+python3 << 'EOF'
+import json, math
+from datetime import datetime, timezone
+from collections import defaultdict
+
+with open("/tmp/tsf_parsed.json") as f:
+    sources = json.load(f)
+
+topic      = "{TOPIC_KEY}"
+from_cache = any(s.get("from_cache") for s in sources)
+
+# ── TTL and cache age ─────────────────────────────────────────────────────
+TTL_DAYS = {"currency_codes":30,"country_codes":30,"address_formats":30,
+            "tld_list":7,"language_codes":30,"http_status_codes":7,
+            "phone_calling_codes":30,"timezones":7}
+topic_ttl = TTL_DAYS.get(topic, 30)
+
+# ── Cache freshness factor ────────────────────────────────────────────────
+cache_freshness = 1.0
+if from_cache:
+    fetched_ats = [s.get("fetched_at") for s in sources if s.get("fetched_at")]
+    if fetched_ats:
+        oldest = min(datetime.fromisoformat(t) for t in fetched_ats)
+        age_d = (datetime.now(timezone.utc) - oldest).total_seconds() / 86400
+        cache_freshness = max(0.5, 1.0 - (age_d / topic_ttl) * 0.5)
+        # Mixed-age warning
+        newest = max(datetime.fromisoformat(t) for t in fetched_ats)
+        delta_d = (newest - oldest).total_seconds() / 86400
+        if delta_d > 7:
+            print(f"MIXED_AGE_WARNING|delta={delta_d:.1f}d")
+
+# ── Conflict detection ────────────────────────────────────────────────────
+# Build a key→field→{source_name: value} index
+field_index = defaultdict(lambda: defaultdict(dict))
+for src in sources:
+    for row in src.get("rows", []):
+        # Use first column as row key
+        cols = src.get("columns", [])
+        if not cols:
+            continue
+        row_key = str(row.get(cols[0], ""))
+        for col in cols[1:]:
+            val = str(row.get(col, "")).strip().lower()
+            field_index[row_key][col][src["name"]] = val
+
+conflicts = []
+total_fields = 0
+for row_key, fields in field_index.items():
+    for field, src_vals in fields.items():
+        total_fields += 1
+        unique_vals = set(src_vals.values())
+        if len(unique_vals) > 1:
+            conflicts.append({"row":row_key,"field":field,"values":src_vals})
+
+conflict_penalty = min(1.0, len(conflicts) / total_fields) if total_fields else 0
+
+# ── Score per source ──────────────────────────────────────────────────────
+EXPECTED = {"currency_codes":180,"country_codes":249,"address_formats":240,
+            "tld_list":1500,"language_codes":184,"http_status_codes":60,
+            "phone_calling_codes":240,"timezones":600,"population_data":217}
+expected = EXPECTED.get(topic, 100)
+n = len(sources)
+
+scored = []
+for src in sources:
+    tier_authority = 1.0 if src["tier"]==1 else (0.7 if not src.get("stale") else 0.5)
+    multiplicity   = min(1.0, math.log2(n+1)/3)
+    freshness      = cache_freshness if src.get("from_cache") else 0.97
+    coverage       = min(1.0, len(src.get("rows",[])) / expected)
+    recurrence     = 0.85 if src["tier"]==1 else 0.6
+    independence   = 1.0
+    base = (0.35*tier_authority + 0.15*multiplicity + 0.15*freshness
+            + 0.15*coverage    + 0.10*recurrence   + 0.10*independence)
+    score = round(100 * base * (1 - conflict_penalty))
+    scored.append({**src, "score":score, "factors":{
+        "tier_authority":tier_authority,"multiplicity":multiplicity,
+        "freshness":freshness,"coverage":coverage,"recurrence":recurrence,
+        "independence":independence,"conflict_penalty":conflict_penalty,
+    }})
+
+scored.sort(key=lambda s: -s["score"])
+winner = scored[0] if scored else None
+
+result = {
+    "topic":          topic,
+    "winner":         winner,
+    "all_sources":    scored,
+    "conflicts":      conflicts[:20],  # cap at 20 for widget
+    "conflict_count": len(conflicts),
+    "from_cache":     from_cache,
+    "cache_freshness":cache_freshness,
+}
+with open("/tmp/tsf_result.json","w") as f:
+    json.dump(result, f, ensure_ascii=False)
+
+print(f"SCORE_DONE|winner={winner['name'] if winner else 'none'}"
+      f"|score={winner['score'] if winner else 0}"
+      f"|conflicts={len(conflicts)}"
+      f"|from_cache={from_cache}")
+EOF
+```
+
+**Parse the output:**
+- `SCORE_DONE|winner=...|score=...|conflicts=...|from_cache=...`
+- `MIXED_AGE_WARNING|delta=...` → add mixed-age warning to widget
+- Full result is in `/tmp/tsf_result.json` — read this to build the widget
+
+---
+
+### Recipe 7 — Read final result for widget rendering
+
+```bash
+python3 -c "
+import json
+with open('/tmp/tsf_result.json') as f:
+    r = json.load(f)
+w = r['winner']
+print(f\"topic={r['topic']}\")
+print(f\"score={w['score']}\")
+print(f\"tier={w['tier']}\")
+print(f\"source_name={w['name']}\")
+print(f\"source_url={w['url']}\")
+print(f\"rows={len(w.get('rows',[]))}\")
+print(f\"from_cache={r['from_cache']}\")
+print(f\"conflict_count={r['conflict_count']}\")
+"
+```
+
+---
+
+### Recipe 8 — Generate i18nify utility files (utility generation path only)
+
+**TRIGGER**: Run this recipe ONLY when the user explicitly asks to generate, scaffold, or create an i18nify utility/module for the resolved topic. Do NOT run on every invocation. Requires Recipe 7 to have already run (i.e. `/tmp/tsf_result.json` exists).
+
+**STRICT OUTPUT CONSTRAINT**: This recipe writes all files directly to the filesystem. It must NOT echo or print raw code content to the terminal. Only `WROTE|{path}` status lines and the final `UTILITY_DONE|` line may appear in stdout.
+
+Replace `{TOPIC_KEY}` (from Step 1) and `{PROJECT_ROOT}` (absolute path to repo root, determined from `git rev-parse --show-toplevel` or conversation context).
+
+```bash
+python3 << 'RECIPE8_EOF'
+import json, os, sys, re
+
+# ── Substitutions ─────────────────────────────────────────────────
+TOPIC_KEY    = "{TOPIC_KEY}"      # from Step 1  e.g. "currency_codes"
+PROJECT_ROOT = "{PROJECT_ROOT}"   # e.g. "/Users/me/i18nify"
+# ─────────────────────────────────────────────────────────────────
+
+# ── Topic → module naming map ─────────────────────────────────────
+TOPIC_MAP = {
+    # ALL topics use id_field="cc" (ISO 3166-1 alpha-2) as the root dict key.
+    # crawl4ai_runner.py guarantees a "cc" field in every output row.
+    "currency_codes":      {"snake": "currency",        "pascal": "Currency",        "data_key": "currency_information",          "id_field": "cc"},
+    "country_codes":       {"snake": "country",         "pascal": "Country",         "data_key": "country_information",           "id_field": "cc"},
+    "phone_calling_codes": {"snake": "phoneNumber",     "pascal": "PhoneNumber",     "data_key": "country_tele_information",      "id_field": "cc"},
+    "language_codes":      {"snake": "language",        "pascal": "Language",        "data_key": "language_information",          "id_field": "cc"},
+    "timezones":           {"snake": "timezone",        "pascal": "Timezone",        "data_key": "timezone_information",          "id_field": "cc"},
+    "tld_list":            {"snake": "tld",             "pascal": "Tld",             "data_key": "tld_information",               "id_field": "cc"},
+    "address_formats":     {"snake": "address",         "pascal": "Address",         "data_key": "address_format_information",    "id_field": "cc"},
+    "country_metadata":    {"snake": "countryMetadata", "pascal": "CountryMetadata", "data_key": "country_metadata_information",  "id_field": "cc"},
+    "gst_rates_india":     {"snake": "gst",             "pascal": "Gst",             "data_key": "gst_information",               "id_field": "code"},
+    "population_data":     {"snake": "population",      "pascal": "Population",      "data_key": "population_information",        "id_field": "cc"},
+}
+
+cfg = TOPIC_MAP.get(TOPIC_KEY)
+if not cfg:
+    print(f"UTILITY_ERROR|unsupported topic '{TOPIC_KEY}' — add a mapping entry in Recipe 8 TOPIC_MAP")
+    sys.exit(1)
+
+snake    = cfg["snake"]      # camelCase module name  e.g. "currency"
+pascal   = cfg["pascal"]     # PascalCase             e.g. "Currency"
+data_key = cfg["data_key"]   # i18nify-data root key  e.g. "currency_information"
+id_field = cfg["id_field"]   # row identifier field   e.g. "code"
+
+# ── Load winner rows from Recipe 7 output ─────────────────────────
+with open("/tmp/tsf_result.json") as f:
+    result = json.load(f)
+winner = result["winner"]
+rows   = winner.get("rows", [])
+if not rows:
+    print("UTILITY_ERROR|winner has no rows — cannot generate data files")
+    sys.exit(1)
+
+# ── Build i18nify-data canonical dict (always keyed by ISO 3166-1 alpha-2 cc) ──
+data_dict = {}
+for row in rows:
+    # "cc" is the universal country-code key guaranteed by crawl4ai_runner.py.
+    # Fall back to id_field (also "cc") then first column value if somehow absent.
+    key = row.get("cc") or row.get(id_field) or str(list(row.values())[0])
+    # Exclude cc / id_field from the value dict to avoid redundancy.
+    data_dict[key] = {k: v for k, v in row.items() if k not in {"cc", id_field}}
+
+canonical_data = {data_key: data_dict}
+
+# ── Derive proto schema recursively from data_dict ────────────────
+
+def _to_pascal(s):
+    """Convert snake_case or camelCase field name to PascalCase."""
+    parts = re.split(r'[_\s]+', s)
+    return ''.join(p.capitalize() for p in parts if p)
+
+def _singularize(name):
+    """Naive English singularization used for naming list-element messages."""
+    if name.endswith('ies') and len(name) > 3:
+        return name[:-3] + 'y'
+    if name.endswith('ses') and len(name) > 4:
+        return name[:-2]
+    if name.endswith('es') and len(name) > 3:
+        return name[:-2]
+    if name.endswith('s') and len(name) > 1:
+        return name[:-1]
+    return name
+
+def _py_to_proto_scalar(v):
+    """Map a Python value to its proto3 scalar type keyword."""
+    if isinstance(v, bool):
+        return "bool"
+    if isinstance(v, int):
+        return "int32"
+    if isinstance(v, float):
+        return "double"
+    return "string"
+
+def _infer_representative(values):
+    """Return first non-empty, non-None value from a list of samples."""
+    for v in values:
+        if v is not None and v != "" and v != [] and v != {}:
+            return v
+    return values[0] if values else None
+
+def _collect_field_samples(entries):
+    """
+    Deep-union all fields across every entry. Collects all keys found in ANY
+    entry, then for each key gathers all values across ALL entries (None for
+    entries missing that key). This ensures fields sparse in the data are still
+    typed correctly — a field present in 1 of 251 entries is not dropped.
+    """
+    # Pass 1: union of all keys in insertion order
+    all_keys: dict = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        for k in entry:
+            all_keys.setdefault(k, len(all_keys))
+
+    # Pass 2: collect every value per key (None for absent entries)
+    acc: dict = {k: [] for k in all_keys}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        for k in all_keys:
+            acc[k].append(entry.get(k, None))
+
+    return {k: _infer_representative(vs) for k, vs in acc.items()}
+
+_proto_messages = []  # (msg_name, comment, field_lines) — deepest sub-messages first
+_proto_seen = set()
+
+def _generate_proto_message(msg_name, comment, field_samples):
+    """
+    Recursively walk field_samples and emit message definitions.
+    - dict values          → named sub-message + singular field
+    - list-of-dict values  → named sub-message + repeated field
+    - list-of-scalar       → repeated <scalar_type> field
+    - scalar               → <scalar_type> field
+    Sub-messages are appended before the parent so proto file reads
+    bottom-up (deepest first), which is valid in proto3.
+    """
+    if msg_name in _proto_seen:
+        return
+    _proto_seen.add(msg_name)
+
+    field_lines = []
+    for idx, (field_name, sample_val) in enumerate(field_samples.items(), start=1):
+        safe = re.sub(r'[^a-zA-Z0-9_]', '_', field_name)
+
+        if isinstance(sample_val, dict) and sample_val:
+            # nested object → dedicated message
+            nested_name = _to_pascal(field_name)
+            nested_samples = _collect_field_samples([sample_val])
+            _generate_proto_message(
+                nested_name,
+                f"// {nested_name} contains nested {field_name} attributes.",
+                nested_samples,
+            )
+            field_lines.append(f"  {nested_name} {safe} = {idx};")
+
+        elif isinstance(sample_val, list) and sample_val:
+            first = sample_val[0]
+            if isinstance(first, dict) and first:
+                # list of objects → dedicated message + repeated field
+                item_name = _to_pascal(_singularize(field_name))
+                item_samples = _collect_field_samples(sample_val)
+                _generate_proto_message(
+                    item_name,
+                    f"// {item_name} represents a single item in the {field_name} list.",
+                    item_samples,
+                )
+                field_lines.append(f"  repeated {item_name} {safe} = {idx};")
+            else:
+                # list of scalars
+                field_lines.append(
+                    f"  repeated {_py_to_proto_scalar(first)} {safe} = {idx};"
+                )
+
+        else:
+            field_lines.append(f"  {_py_to_proto_scalar(sample_val)} {safe} = {idx};")
+
+    _proto_messages.append((msg_name, comment, field_lines))
+
+# Deep-union samples across all entries.
+# enrich_row() in crawl4ai_runner.py guarantees country_name and all standard fields
+# are already present in the canonical data — no sentinel overlay required.
+_collected = _collect_field_samples(list(data_dict.values()))
+_generate_proto_message(
+    f"{pascal}Info",
+    f"// {pascal}Info holds all fields for a single {snake} entry, keyed by country code.",
+    _collected,
+)
+
+# Assemble final .proto: header + root Data message + all generated messages
+_proto_parts = [
+    f'syntax = "proto3";',
+    f'package {snake};',
+    f'option go_package = "github.com/razorpay/i18nify/i18nify-data/go/{snake};{snake}";',
+    "",
+    f"// {pascal}Data is the root message.",
+    f"// The map key is the ISO 3166-1 alpha-2 country code.",
+    f"message {pascal}Data {{",
+    f"  map<string, {pascal}Info> {data_key} = 1;",
+    f"}}",
+]
+for _msg_name, _comment, _flines in _proto_messages:
+    _proto_parts.append("")
+    _proto_parts.append(_comment)
+    _proto_parts.append(f"message {_msg_name} {{")
+    _proto_parts.extend(_flines)
+    _proto_parts.append("}")
+
+f_proto = "\n".join(_proto_parts) + "\n"
+
+# UPPER_SNAKE_CASE from camelCase
+snake_upper = re.sub(r"(?<=[a-z])(?=[A-Z])", "_", snake).upper()
+
+module_dir = os.path.join(PROJECT_ROOT, "packages", "i18nify-js", "src", "modules", snake)
+data_dir   = os.path.join(PROJECT_ROOT, "i18nify-data", snake)
+
+# ── File content templates ─────────────────────────────────────────
+
+# i18nify-data/{snake}/data.json
+f_data_json = json.dumps(canonical_data, ensure_ascii=False, indent=2)
+
+# i18nify-data/{snake}/README.md
+f_readme = (
+    f"# {pascal} Data\n\n"
+    f"Canonical {pascal.lower()} reference data for i18nify.\n\n"
+    f"## Schema\n\n"
+    f"- **Root key**: `{data_key}`\n"
+    f"- **Entry key**: ISO/official `{id_field}` code\n"
+    f"- **Total entries**: {len(data_dict)}\n\n"
+    f"## Source\n\n"
+    f"Data sourced from {winner.get('name', 'authoritative source')} "
+    f"(accuracy score: {winner.get('score', 'N/A')}/100, Tier {winner.get('tier', 'N/A')}).\n"
+)
+
+# packages/.../modules/{snake}/data/{snake}Config.json — compact module-local copy
+# Only include fields commonly used in JS utilities (name, symbol, minor_unit where present)
+CONFIG_FIELDS = {"name", "symbol", "minor_unit"}
+module_config = {
+    k: {fk: fv for fk, fv in v.items() if fk in CONFIG_FIELDS or not CONFIG_FIELDS.intersection(v)}
+    for k, v in data_dict.items()
+}
+f_module_config = json.dumps(module_config, ensure_ascii=False, indent=2)
+
+# packages/.../modules/{snake}/types.ts
+f_types = (
+    f"import {snake_upper}_INFO from './data/{snake}Config.json';\n\n"
+    f"export type {pascal}CodeType = keyof typeof {snake_upper}_INFO;\n\n"
+    f"export interface {pascal}Type {{\n"
+    f"  code: {pascal}CodeType;\n"
+    f"  name: string;\n"
+    f"}}\n"
+)
+
+# packages/.../modules/{snake}/constants.ts
+f_constants = (
+    f"export const {snake_upper}_CODE_LIST = {json.dumps(sorted(data_dict.keys()), ensure_ascii=False, indent=2)} as const;\n"
+)
+
+# packages/.../modules/{snake}/utils.ts
+f_utils = (
+    f"import type {{ {pascal}CodeType }} from './types';\n"
+    f"import {snake_upper}_INFO from './data/{snake}Config.json';\n\n"
+    f"export const get{pascal}Info = (code: {pascal}CodeType) =>\n"
+    f"  ({snake_upper}_INFO as Record<string, unknown>)[code] ?? null;\n"
+)
+
+# packages/.../modules/{snake}/get{Pascal}List.ts
+f_get_list = (
+    f"import {{ withErrorBoundary }} from '../../common/errorBoundary';\n"
+    f"import {snake_upper}_INFO from './data/{snake}Config.json';\n"
+    f"import type {{ {pascal}CodeType }} from './types';\n\n"
+    f"const get{pascal}List = (): Record<{pascal}CodeType, (typeof {snake_upper}_INFO)[{pascal}CodeType]> =>\n"
+    f"  {snake_upper}_INFO as Record<{pascal}CodeType, (typeof {snake_upper}_INFO)[{pascal}CodeType]>;\n\n"
+    f"export default withErrorBoundary<typeof get{pascal}List>(get{pascal}List);\n"
+)
+
+# packages/.../modules/{snake}/index.ts
+f_index = (
+    f"export {{ default as get{pascal}List }} from './get{pascal}List';\n"
+    f"export * from './types';\n"
+    f"export * from './utils';\n"
+)
+
+# packages/.../modules/{snake}/__tests__/get{Pascal}List.test.ts
+f_test = (
+    f"import get{pascal}List from '../get{pascal}List';\n\n"
+    f"describe('get{pascal}List', () => {{\n"
+    f"  it('returns all {snake} entries', () => {{\n"
+    f"    const list = get{pascal}List();\n"
+    f"    expect(typeof list).toBe('object');\n"
+    f"    expect(Object.keys(list).length).toBeGreaterThan(0);\n"
+    f"  }});\n\n"
+    f"  it('each entry has expected shape', () => {{\n"
+    f"    const list = get{pascal}List();\n"
+    f"    const sample = Object.values(list)[0] as Record<string, unknown>;\n"
+    f"    expect(typeof sample).toBe('object');\n"
+    f"  }});\n"
+    f"}});\n"
+)
+
+# ── Write files to filesystem (no content echoed to terminal) ──────
+def write_file(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    rel = os.path.relpath(path, PROJECT_ROOT)
+    print(f"WROTE|{rel}")
+
+write_file(os.path.join(data_dir,   "data.json"),                        f_data_json)
+write_file(os.path.join(data_dir,   "proto", f"{snake}.proto"),          f_proto)
+write_file(os.path.join(data_dir,   "README.md"),                        f_readme)
+write_file(os.path.join(module_dir, "data",  f"{snake}Config.json"),     f_module_config)
+write_file(os.path.join(module_dir, "types.ts"),                         f_types)
+write_file(os.path.join(module_dir, "constants.ts"),                     f_constants)
+write_file(os.path.join(module_dir, "utils.ts"),                         f_utils)
+write_file(os.path.join(module_dir, f"get{pascal}List.ts"),              f_get_list)
+write_file(os.path.join(module_dir, "index.ts"),                         f_index)
+write_file(os.path.join(module_dir, "__tests__", f"get{pascal}List.test.ts"), f_test)
+
+print(f"UTILITY_DONE|{snake}|files=10|entries={len(data_dict)}")
+RECIPE8_EOF
+```
+
+**Parse the output:**
+- `WROTE|{rel_path}` lines → collect into file list for summary
+- `UTILITY_DONE|{snake}|files={n}|entries={m}` → generation succeeded
+- `UTILITY_ERROR|{message}` → halt, display error per Section 11 rules
+- Non-zero exit or Traceback → halt, display error per Section 11 rules
+
+**After Recipe 8 completes:** Use the **Write tool** (not bash) to update `packages/i18nify-js/src/index.ts` — append `export * from './modules/{snake}';` on a new line at the end of the existing module exports block. Read the file first to find the correct insertion point.
+
+---
+
+### Recipe 8-Go — Generate Go utility files (always runs after Recipe 8 on utility generation path)
+
+**TRIGGER**: Run this recipe immediately after Recipe 8 on every utility generation invocation. Do NOT skip it — Go files are always generated alongside JS files.
+
+**STRICT OUTPUT CONSTRAINT**: Like Recipe 8, writes files directly to filesystem. Only `WROTE|{path}`, `SKIP|{path}`, and the final `GO_UTILITY_DONE|` line may appear in stdout. No raw code.
+
+Replace `{TOPIC_KEY}` (from Step 1) and `{PROJECT_ROOT}` (from Step A).
+
+```bash
+python3 << 'RECIPE8GO_EOF'
+import json, os, sys, re
+
+# ── Substitutions ─────────────────────────────────────────────────
+TOPIC_KEY    = "{TOPIC_KEY}"
+PROJECT_ROOT = "{PROJECT_ROOT}"
+# ─────────────────────────────────────────────────────────────────
+
+TOPIC_MAP = {
+    "currency_codes":      {"snake": "currency",        "pascal": "Currency",        "data_key": "currency_information",         "go_pkg": "currency"},
+    "country_codes":       {"snake": "country",         "pascal": "Country",         "data_key": "country_information",          "go_pkg": "country"},
+    "phone_calling_codes": {"snake": "phoneNumber",     "pascal": "PhoneNumber",     "data_key": "country_tele_information",     "go_pkg": "phonenumber"},
+    "language_codes":      {"snake": "language",        "pascal": "Language",        "data_key": "language_information",         "go_pkg": "language"},
+    "timezones":           {"snake": "timezone",        "pascal": "Timezone",        "data_key": "timezone_information",         "go_pkg": "timezone"},
+    "tld_list":            {"snake": "tld",             "pascal": "Tld",             "data_key": "tld_information",              "go_pkg": "tld"},
+    "address_formats":     {"snake": "address",         "pascal": "Address",         "data_key": "address_format_information",   "go_pkg": "address"},
+    "country_metadata":    {"snake": "countryMetadata", "pascal": "CountryMetadata", "data_key": "country_metadata_information", "go_pkg": "countrymetadata"},
+    "gst_rates_india":     {"snake": "gst",             "pascal": "Gst",             "data_key": "gst_information",              "go_pkg": "gst"},
+    "population_data":     {"snake": "population",      "pascal": "Population",      "data_key": "population_information",       "go_pkg": "population"},
+}
+
+cfg = TOPIC_MAP.get(TOPIC_KEY)
+if not cfg:
+    print(f"GO_UTILITY_ERROR|unsupported topic '{TOPIC_KEY}' — add a mapping entry in Recipe 8-Go TOPIC_MAP")
+    sys.exit(1)
+
+snake    = cfg["snake"]
+pascal   = cfg["pascal"]
+data_key = cfg["data_key"]
+go_pkg   = cfg["go_pkg"]
+
+# ── Load canonical data ───────────────────────────────────────────
+data_path = os.path.join(PROJECT_ROOT, "i18nify-data", snake, "data.json")
+if not os.path.exists(data_path):
+    data_path = os.path.join(PROJECT_ROOT, "i18nify-data", go_pkg, "data.json")
+if not os.path.exists(data_path):
+    print(f"GO_UTILITY_ERROR|canonical data not found at i18nify-data/{snake}/data.json")
+    sys.exit(1)
+
+with open(data_path, encoding="utf-8") as f:
+    canonical = json.load(f)
+
+data_dict = canonical.get(data_key, {})
+if not data_dict:
+    print(f"GO_UTILITY_ERROR|key '{data_key}' not found in canonical data")
+    sys.exit(1)
+
+# ── Helpers ────────────────────────────────────────────────────────
+def _to_pascal(s):
+    parts = re.split(r'[_\s]+', s)
+    return ''.join(p.capitalize() for p in parts if p)
+
+def _go_type(val):
+    if val is None: return "string"
+    if isinstance(val, bool): return "bool"
+    if isinstance(val, int): return "int32"
+    if isinstance(val, float): return "float64"
+    if isinstance(val, list):
+        if not val: return "[]string"
+        first = val[0]
+        if isinstance(first, str): return "[]string"
+        if isinstance(first, bool): return "[]bool"
+        if isinstance(first, int): return "[]int32"
+        return "json.RawMessage"
+    if isinstance(val, dict): return "json.RawMessage"
+    return "string"
+
+def _go_zero(go_type):
+    if go_type == "string": return '""'
+    if go_type in ("int32", "int64", "float64"): return "0"
+    if go_type == "bool": return "false"
+    return "nil"
+
+def _collect_samples(entries):
+    all_keys = {}
+    for entry in entries:
+        if isinstance(entry, dict):
+            for k in entry:
+                all_keys.setdefault(k, None)
+    for k in all_keys:
+        for entry in entries:
+            if isinstance(entry, dict) and k in entry:
+                v = entry[k]
+                if v is not None and v != "" and v != [] and v != {}:
+                    all_keys[k] = v
+                    break
+    return all_keys
+
+def write_file(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    rel = os.path.relpath(path, PROJECT_ROOT)
+    print(f"WROTE|{rel}")
+
+samples = _collect_samples(list(data_dict.values()))
+fields_named = [(_to_pascal(fname), _go_type(fval), fname) for fname, fval in samples.items()]
+data_key_pascal = _to_pascal(data_key)
+needs_json_import = any(gt == "json.RawMessage" for _, gt, _ in fields_named)
+
+# ── 1. {go_pkg}.pb.go ─────────────────────────────────────────────
+pb_lines = [
+    f"// Hand-written Go structs mirroring {go_pkg}.proto — protoc not available.",
+    f"// Matches the canonical i18nify-data/{go_pkg}/data.json schema.",
+    "",
+    f"package {go_pkg}",
+    "",
+]
+if needs_json_import:
+    pb_lines += ['import "encoding/json"', '']
+
+pb_lines += [
+    f"// {pascal}Data is the root container.",
+    f"type {pascal}Data struct {{",
+    f'\t{data_key_pascal} map[string]*{pascal}Info `json:"{data_key},omitempty"`',
+    "}",
+    "",
+    f"func (x *{pascal}Data) Get{data_key_pascal}() map[string]*{pascal}Info {{",
+    "\tif x != nil {",
+    f"\t\treturn x.{data_key_pascal}",
+    "\t}",
+    "\treturn nil",
+    "}",
+    "",
+    f"// {pascal}Info holds all fields for a single {go_pkg} entry.",
+    f"type {pascal}Info struct {{",
+]
+for gfname, gtype, jname in fields_named:
+    pb_lines.append(f'\t{gfname} {gtype} `json:"{jname},omitempty"`')
+pb_lines += ["}", ""]
+for gfname, gtype, jname in fields_named:
+    pb_lines += [
+        f"func (x *{pascal}Info) Get{gfname}() {gtype} {{",
+        "\tif x != nil {",
+        f"\t\treturn x.{gfname}",
+        "\t}",
+        f"\treturn {_go_zero(gtype)}",
+        "}",
+        "",
+    ]
+f_go_pb = "\n".join(pb_lines) + "\n"
+
+# ── 2. data_loader.go ─────────────────────────────────────────────
+f_go_loader = (
+    "// Code generated by i18nify go generator. DO NOT EDIT.\n\n"
+    f"package {go_pkg}\n\n"
+    'import (\n\t_ "embed"\n\t"encoding/json"\n\t"sync"\n)\n\n'
+    '//go:embed data/data.json\n'
+    'var dataJSON []byte\n\n'
+    'var (\n'
+    f'\tdata     *{pascal}Data\n'
+    '\tdataOnce sync.Once\n'
+    '\tdataErr  error\n'
+    ')\n\n'
+    f'// Get{pascal}Data retrieves the {go_pkg} data.\n'
+    f'func Get{pascal}Data() (*{pascal}Data, error) {{\n'
+    '\tdataOnce.Do(func() {\n'
+    f'\t\tdata = &{pascal}Data{{}}\n'
+    '\t\tdataErr = json.Unmarshal(dataJSON, data)\n'
+    '\t})\n'
+    '\treturn data, dataErr\n'
+    '}\n'
+)
+
+# ── 3. data_loader_test.go ────────────────────────────────────────
+f_go_loader_test = (
+    "// Code generated by i18nify go generator. DO NOT EDIT.\n\n"
+    f"package {go_pkg}\n\n"
+    'import (\n\t"testing"\n)\n\n'
+    f'func TestGet{pascal}Data(t *testing.T) {{\n'
+    f'\tdata, err := Get{pascal}Data()\n'
+    '\tif err != nil {\n'
+    f'\t\tt.Fatalf("Get{pascal}Data() error = %v", err)\n'
+    '\t}\n'
+    '\tif data == nil {\n'
+    f'\t\tt.Fatal("Get{pascal}Data() returned nil data")\n'
+    '\t}\n'
+    '\tt.Log("Data loaded successfully")\n'
+    '}\n\n'
+    f'func TestGet{pascal}Data_Idempotent(t *testing.T) {{\n'
+    f'\tdata1, err1 := Get{pascal}Data()\n'
+    '\tif err1 != nil {\n'
+    f'\t\tt.Fatalf("First Get{pascal}Data() error = %v", err1)\n'
+    '\t}\n'
+    f'\tdata2, err2 := Get{pascal}Data()\n'
+    '\tif err2 != nil {\n'
+    f'\t\tt.Fatalf("Second Get{pascal}Data() error = %v", err2)\n'
+    '\t}\n'
+    '\tif data1 != data2 {\n'
+    f'\t\tt.Error("Get{pascal}Data() should return cached data on subsequent calls")\n'
+    '\t}\n'
+    '}\n\n'
+    f'func TestGet{pascal}Data_NotEmpty(t *testing.T) {{\n'
+    f'\tdata, err := Get{pascal}Data()\n'
+    '\tif err != nil {\n'
+    f'\t\tt.Fatalf("Get{pascal}Data() error = %v", err)\n'
+    '\t}\n'
+    '\tif data == nil {\n'
+    '\t\tt.Error("Data should not be nil")\n'
+    '\t}\n'
+    f'\tif len(data.Get{data_key_pascal}()) == 0 {{\n'
+    f'\t\tt.Error("{data_key_pascal} should not be empty")\n'
+    '\t}\n'
+    '}\n'
+)
+
+# ── 4. go.mod for i18nify-data/go/{go_pkg} ───────────────────────
+f_go_mod = (
+    f"module github.com/razorpay/i18nify/i18nify-data/go/{go_pkg}\n\ngo 1.20\n"
+)
+
+# ── 5. packages/i18nify-go/modules/{snake}/{go_pkg}.go ─────────────
+mod_info_fields = "\n".join(
+    f'\t{gfname} {gtype} `json:"{jname}"`'
+    for gfname, gtype, jname in fields_named
+)
+f_go_module = (
+    f"// Package {go_pkg} provides {go_pkg} information keyed by ISO 3166-1 alpha-2 country code.\n"
+    f"package {go_pkg}\n\n"
+    'import (\n\t"encoding/json"\n\t"fmt"\n\n'
+    f'\tdataSource "github.com/razorpay/i18nify/i18nify-data/go/{go_pkg}"\n'
+    ')\n\n'
+    f'// {pascal}Info contains data for a single {go_pkg} entry.\n'
+    f'type {pascal}Info struct {{\n'
+    + mod_info_fields + "\n"
+    '}\n\n'
+    f'// {pascal}Data holds {go_pkg} information keyed by ISO 3166-1 alpha-2 country code.\n'
+    f'type {pascal}Data struct {{\n'
+    f'\t{data_key_pascal} map[string]{pascal}Info `json:"{data_key}"`\n'
+    '}\n\n'
+    f'var cached{pascal}Data *{pascal}Data\n\n'
+    'func init() {\n'
+    f'\tsrc, err := dataSource.Get{pascal}Data()\n'
+    '\tif err != nil {\n'
+    f'\t\tpanic(fmt.Sprintf("failed to load {go_pkg} data: %v", err))\n'
+    '\t}\n'
+    '\tdata := convertFromDataSource(src)\n'
+    f'\tcached{pascal}Data = &data\n'
+    '}\n\n'
+    f'func convertFromDataSource(src *dataSource.{pascal}Data) {pascal}Data {{\n'
+    '\tif src == nil {\n'
+    f'\t\treturn {pascal}Data{{}}\n'
+    '\t}\n'
+    f'\tinfo := make(map[string]{pascal}Info, len(src.Get{data_key_pascal}()))\n'
+    f'\tfor cc, entry := range src.Get{data_key_pascal}() {{\n'
+    '\t\tif entry == nil {\n'
+    '\t\t\tcontinue\n'
+    '\t\t}\n'
+    '\t\tb, _ := json.Marshal(entry)\n'
+    f'\t\tvar v {pascal}Info\n'
+    '\t\tif err := json.Unmarshal(b, &v); err != nil {\n'
+    '\t\t\tcontinue\n'
+    '\t\t}\n'
+    '\t\tinfo[cc] = v\n'
+    '\t}\n'
+    f'\treturn {pascal}Data{{{data_key_pascal}: info}}\n'
+    '}\n\n'
+    f'// Unmarshal{pascal}Data parses JSON data into a {pascal}Data struct.\n'
+    f'func Unmarshal{pascal}Data(data []byte) ({pascal}Data, error) {{\n'
+    f'\tvar r {pascal}Data\n'
+    '\terr := json.Unmarshal(data, &r)\n'
+    '\treturn r, err\n'
+    '}\n\n'
+    f'// Get{pascal}List returns all {go_pkg} entries keyed by country code.\n'
+    f'func Get{pascal}List() map[string]{pascal}Info {{\n'
+    f'\treturn cached{pascal}Data.{data_key_pascal}\n'
+    '}\n\n'
+    f'// Get{pascal}Info returns the {go_pkg} entry for the given ISO 3166-1 alpha-2 country code.\n'
+    f'func Get{pascal}Info(cc string) ({pascal}Info, error) {{\n'
+    '\tif cc == "" {\n'
+    f'\t\treturn {pascal}Info{{}}, fmt.Errorf("country code cannot be empty")\n'
+    '\t}\n'
+    f'\tinfo, exists := cached{pascal}Data.{data_key_pascal}[cc]\n'
+    '\tif !exists {\n'
+    f'\t\treturn {pascal}Info{{}}, fmt.Errorf("{pascal} info for country code \'%s\' not found", cc)\n'
+    '\t}\n'
+    '\treturn info, nil\n'
+    '}\n'
+)
+
+# ── 6. packages/i18nify-go/modules/{snake}/{go_pkg}_test.go ───────
+f_go_module_test = (
+    f"package {go_pkg}\n\n"
+    'import (\n\t"testing"\n\n\t"github.com/stretchr/testify/assert"\n)\n\n'
+    f'func TestGet{pascal}List(t *testing.T) {{\n'
+    f'\tlist := Get{pascal}List()\n'
+    '\tassert.NotEmpty(t, list)\n'
+    '\tfor cc, info := range list {\n'
+    '\t\tassert.Len(t, cc, 2, "country code should be 2 chars: %s", cc)\n'
+    '\t\t_ = info\n'
+    '\t}\n'
+    '}\n\n'
+    f'func TestGet{pascal}Info_Invalid(t *testing.T) {{\n'
+    f'\t_, err := Get{pascal}Info("XX")\n'
+    '\tassert.Error(t, err)\n\n'
+    f'\t_, err = Get{pascal}Info("")\n'
+    '\tassert.Error(t, err)\n'
+    '}\n\n'
+    f'func TestUnmarshal{pascal}Data(t *testing.T) {{\n'
+    f'\tlist := Get{pascal}List()\n'
+    '\tassert.NotEmpty(t, list)\n'
+    '}\n'
+)
+
+# ── Write i18nify-data/go/{go_pkg}/ ──────────────────────────────
+go_data_dir = os.path.join(PROJECT_ROOT, "i18nify-data", "go", go_pkg)
+write_file(os.path.join(go_data_dir, f"{go_pkg}.pb.go"),     f_go_pb)
+write_file(os.path.join(go_data_dir, "data_loader.go"),      f_go_loader)
+write_file(os.path.join(go_data_dir, "data_loader_test.go"), f_go_loader_test)
+write_file(os.path.join(go_data_dir, "data", "data.json"),   json.dumps(canonical, ensure_ascii=False, indent=2))
+write_file(os.path.join(go_data_dir, "go.mod"),              f_go_mod)
+
+# ── Write packages/i18nify-go/modules/{snake}/ ───────────────────
+go_mod_dir = os.path.join(PROJECT_ROOT, "packages", "i18nify-go", "modules", snake)
+write_file(os.path.join(go_mod_dir, f"{go_pkg}.go"),         f_go_module)
+write_file(os.path.join(go_mod_dir, f"{go_pkg}_test.go"),    f_go_module_test)
+
+# ── Update packages/i18nify-go/go.mod ────────────────────────────
+pkg_go_mod_path = os.path.join(PROJECT_ROOT, "packages", "i18nify-go", "go.mod")
+with open(pkg_go_mod_path, encoding="utf-8") as f:
+    go_mod_content = f.read()
+
+dep_module = f"github.com/razorpay/i18nify/i18nify-data/go/{go_pkg}"
+if dep_module not in go_mod_content:
+    go_mod_content = go_mod_content.rstrip()
+    last_paren = go_mod_content.rfind("\n)")
+    if last_paren >= 0:
+        require_line = f"\n\t{dep_module} v1.0.0"
+        go_mod_content = go_mod_content[:last_paren] + require_line + go_mod_content[last_paren:]
+    else:
+        go_mod_content += f"\nrequire {dep_module} v1.0.0\n"
+    go_mod_content += f"\nreplace {dep_module} => ../../i18nify-data/go/{go_pkg}\n"
+    with open(pkg_go_mod_path, "w", encoding="utf-8") as f:
+        f.write(go_mod_content)
+    print(f"WROTE|packages/i18nify-go/go.mod")
+else:
+    print(f"SKIP|packages/i18nify-go/go.mod (dependency already present)")
+
+print(f"GO_UTILITY_DONE|{snake}|files=8|entries={len(data_dict)}")
+RECIPE8GO_EOF
+```
+
+**Parse the output:**
+- `WROTE|{rel_path}` lines → collect into file list for summary
+- `SKIP|{rel_path}` → dependency already present, no action needed
+- `GO_UTILITY_DONE|{snake}|files={n}|entries={m}` → generation succeeded
+- `GO_UTILITY_ERROR|{message}` → halt, display error per Section 11 rules
+- Non-zero exit or Traceback → halt, display error per Section 11 rules
+
+---
+
+### Temp file map (summary)
+
+| File | Written by | Read by | Contents |
+|------|-----------|---------|----------|
+| `/tmp/tsf_cache_data.json` | Recipe 2 | Recipe 5 | Full pre-fetch envelope JSON |
+| `/tmp/tsf_parsed.json` | Recipe 5 | Recipe 6 | Normalised source data array |
+| `/tmp/tsf_result.json` | Recipe 6 | Recipe 7 | Winner, scores, conflicts |
+
+---
+
+## Section 12 — i18nify Utility Generation
+
+### Trigger conditions
+
+Run this section when the user explicitly requests any of:
+- "generate a utility for [topic]"
+- "scaffold a module for [topic]"
+- "create i18nify module for [topic]"
+- "build the [topic] utility"
+- "generate code for [topic]"
+
+Do NOT run this section on a plain `/utility-creator [topic]` invocation — only when utility generation is explicitly requested.
+
+### Pre-conditions
+
+Steps 1–7 of Section 6 must have already executed. `/tmp/tsf_result.json` must exist with a valid winner. If it does not exist, run Steps 1–7 first, then continue here.
+
+### Step A — Determine PROJECT_ROOT
+
+Run: `git -C "$(pwd)" rev-parse --show-toplevel` via bash_tool.
+Set `{PROJECT_ROOT}` to the output (trim trailing newline).
+
+### Step B — Run Recipe 8
+
+Run Section 2-C **Recipe 8** via bash_tool. Substitute:
+- `{TOPIC_KEY}` — canonical topic key from Step 1 (e.g. `currency_codes`)
+- `{PROJECT_ROOT}` — from Step A
+
+Check stdout character by character:
+- Each `WROTE|{path}` → collect path into written-files list
+- `UTILITY_DONE|{snake}|files={n}|entries={m}` → generation succeeded; extract snake, n, m
+- `UTILITY_ERROR|{message}` → halt, display per Section 11
+- Any Traceback or non-zero exit → halt, display per Section 11
+
+### Step B-Go — Run Recipe 8-Go
+
+Immediately after Step B succeeds, run Section 2-C **Recipe 8-Go** via bash_tool. Substitute the same `{TOPIC_KEY}` and `{PROJECT_ROOT}` values.
+
+Check stdout:
+- Each `WROTE|{path}` → collect into written-files list
+- Each `SKIP|{path}` → note as already-present, no error
+- `GO_UTILITY_DONE|{snake}|files={n}|entries={m}` → succeeded
+- `GO_UTILITY_ERROR|{message}` → halt, display per Section 11
+- Any Traceback or non-zero exit → halt, display per Section 11
+
+### Step C — Update src/index.ts barrel
+
+Using the **Read tool**, read `packages/i18nify-js/src/index.ts` and check whether the line `export * from './modules/{snake}';` already exists in the file.
+
+- **If it already exists**: skip this step entirely — do not make any edit.
+- **If it does not exist**: use the **Edit tool** (not bash, not Write) to find the last `export * from './modules/...';` line and append `export * from './modules/{snake}';` immediately after it on a new line. Do not rewrite the whole file.
+
+### Step D — Output summary (NO raw code; scoring diagnostic required)
+
+Output a markdown summary table of files written, then the scoring diagnostic block from Section 9.5. Do NOT print or echo any generated file content. Example output:
+
+```
+✅ i18nify utility generated: {snake} ({n} JS files + {n_go} Go files, {m} data entries)
+
+| File | Type |
+|------|------|
+| i18nify-data/{snake}/data.json | Canonical data |
+| i18nify-data/{snake}/proto/{snake}.proto | Protobuf schema definition |
+| i18nify-data/{snake}/README.md | Documentation |
+| packages/i18nify-js/src/modules/{snake}/data/{snake}Config.json | Module-local data |
+| packages/i18nify-js/src/modules/{snake}/types.ts | TypeScript types |
+| packages/i18nify-js/src/modules/{snake}/constants.ts | Constants |
+| packages/i18nify-js/src/modules/{snake}/utils.ts | Utilities |
+| packages/i18nify-js/src/modules/{snake}/get{Pascal}List.ts | Main function |
+| packages/i18nify-js/src/modules/{snake}/index.ts | Barrel exports |
+| packages/i18nify-js/src/modules/{snake}/__tests__/get{Pascal}List.test.ts | Tests |
+| packages/i18nify-js/src/index.ts | Updated barrel |
+| i18nify-data/go/{go_pkg}/{go_pkg}.pb.go | Go proto structs |
+| i18nify-data/go/{go_pkg}/data_loader.go | Go data loader (//go:embed) |
+| i18nify-data/go/{go_pkg}/data_loader_test.go | Go data loader tests |
+| i18nify-data/go/{go_pkg}/data/data.json | Go embedded data |
+| i18nify-data/go/{go_pkg}/go.mod | Go module definition |
+| packages/i18nify-go/modules/{snake}/{go_pkg}.go | Go accessor module |
+| packages/i18nify-go/modules/{snake}/{go_pkg}_test.go | Go accessor tests |
+| packages/i18nify-go/go.mod | Updated (added {go_pkg} dep) |
+```
+
+After the table, run the Section 9.5 bash snippet and print the scoring diagnostic block verbatim. Example tail of output:
+
+```
+╔══════════════════════════════════════════════════════════╗
+║           TSF SCORING & DIAGNOSTICS SUMMARY              ║
+╚══════════════════════════════════════════════════════════╝
+
+  Topic          : address_formats
+  Winning source : Google i18n address data
+  Source URL     : https://chromium-i18n.appspot.com/ssl-address/data/
+  Tier           : Tier 1 (Official (T1))
+  Rows fetched   : 249
+  From cache     : False
+  Conflicts      : 0
+
+  ── Score breakdown (weight × raw value) ──────────────────
+
+  tier_authority  (×0.35)  [████████████████████] 1.00
+  multiplicity    (×0.15)  [██████████░░░░░░░░░░] 0.50
+  freshness       (×0.15)  [███████████████████░] 0.97
+  coverage        (×0.15)  [████████████████████] 1.00
+  recurrence      (×0.10)  [█████████████████░░░] 0.85
+  independence    (×0.10)  [████████████████████] 1.00
+
+  conflict_penalty         -0.00  (applied after base)
+
+  ─────────────────────────────────────────────────────────
+  FINAL ACCURACY SCORE     91/100
+══════════════════════════════════════════════════════════════
+```
+
+### File pattern reference (for generated files)
+
+The generated files follow the patterns established in `packages/i18nify-js/src/modules/currency` and `packages/i18nify-js/src/modules/phoneNumber`:
+
+| Pattern | Detail |
+|---------|--------|
+| All function exports | Wrapped: `withErrorBoundary<typeof fn>(fn)` |
+| Module data | Imported from `./data/{snake}Config.json` — compact subset of canonical data |
+| Canonical data | In `i18nify-data/{snake}/data.json` under a `{data_key}` root key |
+| Type alias | `{Pascal}CodeType = keyof typeof {SNAKE_UPPER}_INFO` |
+| External data import | Via TypeScript path alias `#/i18nify-data/...` when needed |
+| Proto schema | `syntax = "proto3"` with `map<string, {Pascal}Info>` and go_package option |
+
+---
+
+## Section 13 — Handling Unknown Topics (Research & Registry Proposal)
+
+### Directive: the registry is a cache, not a ceiling
+
+Your primary directive is to find technical sources. The internal registry (Section 2) is a cache of previously solved topics, not a limitation of your capabilities. An unknown topic is a **research assignment**, not a failure condition.
+
+- **DO NOT** route to Section 8 the moment a topic is not in the registry.
+- **DO** use `web_search` and `web_fetch` to hunt for the official T1/T2 authoritative source (government portals, standards bodies, official registries).
+- **Evaluate** every found source against the strict T1/T2 criteria from Section 1.
+- **If a valid source is found**, produce a Section 13 registry-addition proposal (Step D below).
+- **Only emit Section 8** after exhaustive web searching proves no T1/T2 source exists anywhere on the internet.
+
+### Step A — Web search hunt (3 targeted queries)
+
+Run these three searches in order, stopping at the first that yields a T1 or T2 source:
+
+1. `"{topic} {jurisdiction} official dataset site:gov OR site:int OR site:org"`
+2. `"{topic} {jurisdiction} ISO OR IANA OR ITU OR Unicode OR W3C official"`
+3. `"{topic} {jurisdiction} machine-readable JSON OR XML OR CSV official"`
+
+Substitute `{jurisdiction}` when scope is country-specific (e.g. "Australia ATO GST rates").  
+Substitute `{topic}` with the normalised topic name from the user's query.
+
+### Step B — Classify every result
+
+Apply the Section 1 tier criteria to each found source:
+
+| Classification | Criteria | Action |
+|---|---|---|
+| **Tier 1** | Maintained by the owning standards body or government agency | Accept — proceed to Step C |
+| **Tier 2** | Mirrors a T1 source; clear citation chain; actively maintained | Accept as fallback — proceed to Step C |
+| **Tier 3** | Community / blog / npm / GitHub without cited upstream | Discard immediately |
+
+If only T3 sources survive → all three searches exhausted → route to Section 8.  
+If any T1 or T2 source found → continue to Step C.
+
+### Step C — Assess machine-readability
+
+| Source type | Action |
+|---|---|
+| JSON / XML / CSV endpoint | Propose new pipeline topic (Step D) |
+| HTML page (SPA or static) | Propose Crawl4AI strategy (Step D) |
+| PDF only | Propose PyMuPDF parser — cite CBIC GST as precedent (Step D) |
+| Paywalled / login-required | Check if T2 mirror exists; if so propose T2; otherwise note in proposal |
+| Human-readable only, no download | Section 8 — note the limitation honestly |
+
+### Step D — Registry-addition proposal
+
+When a valid T1/T2 source is confirmed, output this structured proposal. Do NOT silently proceed to fetch data — propose first and let the user approve before any pipeline changes are made.
+
+```
+## New Topic Proposal: {topic_key}
+
+**Source found**: {source_name}  
+**URL**: {source_url}  
+**Tier**: T{1 or 2}  
+**Machine-readable format**: {JSON | XML | CSV | PDF | HTML}  
+**Estimated coverage**: ~{n} entries  
+
+### Changes required to add this topic to the pipeline
+
+**1. SKILL.md — Add to Section 2 source registry:**
+### {topic_key}
+Synonyms: `{comma-separated synonyms}`
+- T{tier}: {source_name} — `{source_url}`
+- Expected coverage: ~{n} entries
+
+**2. crawl4ai_runner.py — Add fetch + parse functions:**
+def fetch_{snake}():     # downloads from {source_url}
+def parse_{snake}(raw):  # returns list[dict] with fields {field_list}
+
+**3. schemas/i18nify_schemas.py — Add Pydantic schema:**
+class {Pascal}(BaseModel):
+    {field: type for each field}
+
+**4. Canonical data path**: i18nify-data/{snake}/data.json  
+   Root key: {data_key}  
+   Entry key: {id_field}
+
+Would you like me to implement these changes?
+```
+
+### Section 8 is the last resort, not the first
+
+Section 8 is only correct when **all** of the following are true:
+
+1. The topic is not in the registry (Section 2)
+2. All three web search queries in Step A returned no T1/T2 sources
+3. Every found source classified as T3 or lower after applying Section 1 criteria
+
+If even one T1 or T2 source is found anywhere, respond with the Step D proposal instead of Section 8.
+
+---

--- a/.claude/skills/utility-creator/docs/3_SCORING_AND_UI.md
+++ b/.claude/skills/utility-creator/docs/3_SCORING_AND_UI.md
@@ -1,0 +1,501 @@
+# Technical Source Finder — Scoring, UI & Output
+
+This file is a supplement to the root [`SKILL.md`](../SKILL.md).
+It contains Sections 3, 4, 5, 7, 8, 9, and 9.5.
+
+---
+
+## Section 3 — Scoring model (Model B)
+
+### Formula
+
+```
+score = 100 × (
+    0.35 × tier_authority
+  + 0.15 × multiplicity
+  + 0.15 × freshness
+  + 0.15 × coverage
+  + 0.10 × recurrence
+  + 0.10 × independence
+) × (1 − conflict_penalty)
+```
+
+Final range: 0–100. All factor values normalised to 0.0–1.0 before weighting.
+
+### Why this formula
+
+Tier authority carries the highest weight (0.35) because it's the only factor measuring signal-of-truth. Every other factor measures signal-of-agreement — and agreement is useless if the sources copied each other. Without tier weighting, ten SEO blogs would outscore one ISO standard.
+
+Conflict is a multiplier, not a subtractor. An additive penalty lets a high base score absorb large disagreements. Multiplier collapses correctly: 100% disagreement → score 0.
+
+### Computing each factor
+
+tier_authority — Look up tier (Section 1). T1=1.0, T2 fresh=0.7, T2 stale=0.5.
+
+multiplicity — Log-scaled count of sources that returned data (excluding T3).
+```
+multiplicity = min(1.0, log2(n_sources + 1) / 3)
+```
+1 src=0.33, 2=0.53, 3=0.67, 5=0.86, 7+=1.0. Log scale because the 1st-to-2nd source is more meaningful than the 5th-to-6th.
+
+freshness — Linear decay against the topic TTL (same TTL table as the cache resolver).
+```
+cache_freshness = max(0.5, 1.0 - (age_days / topic_ttl_days) * 0.5)
+```
+A just-refreshed cache → 1.0. At the TTL boundary → 0.5. Never below 0.5.
+For live fetches (not from cache), freshness is fixed at 0.97.
+
+| Topic class   | TTL (days) | freshness at TTL boundary |
+|---------------|-----------|--------------------------|
+| ISO standards | 30        | 0.5                      |
+| IANA registry |  7        | 0.5                      |
+| Phone / addr  | 30        | 0.5                      |
+| Live fetch    | n/a       | 0.97 (fixed)             |
+
+coverage — Fraction of expected rows returned.
+```
+coverage = min(1.0, rows_returned / expected_rows)
+```
+Use expected counts from Section 2. If unknown topic, set expected = max rows seen across sources.
+
+recurrence — Average of two parts.
+- source_recurrence = `min(1.0, citations_count / 10)` — how many trusted sources cite this one upstream
+- value_recurrence = fraction of fields where this source's value matches the most-common value
+- recurrence = (source_recurrence + value_recurrence) / 2
+
+independence — Fraction of agreeing sources with distinct upstreams.
+```
+independence = len(unique_upstreams) / len(agreeing_sources)
+```
+If 5 sources all cite Wikipedia → 0.2. If 5 cite 5 different standards bodies → 1.0. Catches echo-chamber agreement.
+
+conflict_penalty — see Section 4.
+
+### Worked example
+
+Query: "ISO 4217 currency codes". Sources: SIX Group (T1), datahub.io (T2), restcountries (T2).
+
+For SIX Group (winning source):
+
+| Factor | Value | × Weight | Subtotal |
+|---|---|---|---|
+| tier_authority | 1.0 | 0.35 | 0.350 |
+| multiplicity | 0.67 (3 sources) | 0.15 | 0.100 |
+| freshness | 0.95 (8 months, iso class) | 0.15 | 0.143 |
+| coverage | 1.0 (178/178) | 0.15 | 0.150 |
+| recurrence | 0.85 | 0.10 | 0.085 |
+| independence | 0.67 (2 distinct upstreams) | 0.10 | 0.067 |
+| Base | | | 0.895 |
+
+No conflicts → conflict_penalty = 0.
+Final = 100 × 0.895 × (1 − 0) = 90 → 90/100, T1, six-group.com.
+
+### Score classification
+
+| Score | Class | UI color | Meaning |
+|---|---|---|---|
+| 85–100 | high | green | T1, fresh, complete, no conflicts |
+| 65–84 | mid | amber | T2 mirror or older T1 |
+| 0–64 | low | red | Stale, partial, conflicting, or T3 only |
+
+---
+
+## Section 4 — Conflict handling
+
+### Detection — field-by-field, not source-by-source
+
+Two sources can agree on 100 fields and disagree on 2 — only those 2 count.
+
+```
+For each (row_key, field) pair across all sources:
+  values_seen = { source.value for each source reporting that field }
+  if |values_seen| == 1 → field agrees
+  if |values_seen| > 1 → field conflicts, record which sources hold which value
+```
+
+### Normalise before comparing
+
+Avoid false-positive conflicts:
+- Strip whitespace, lowercase strings (case-insensitive)
+- Parse numbers (don't compare "5" string to 5 number)
+- Strip leading + on phone codes
+- Parse dates to ISO format
+
+### Tie-breaking — which value wins (apply in order, stop at first that resolves)
+
+Rule 1 — Tier priority. Highest-tier source wins. A T1 holding value X beats any number of T2/T3 sources holding Y.
+
+Rule 2 — Majority within tier. If multiple sources at highest tier disagree, majority wins.
+
+Rule 3 — Topic specificity. Prefer source whose mandate matches the topic:
+- ITU wins over ISO for phone-related data
+- ISO wins over IANA for country codes
+- IANA wins over ISO for timezones
+- Unicode wins for character/locale data
+
+Rule 4 — Freshness. Most recently updated wins.
+
+Rule 5 — Unresolved. If still tied, flag as unresolved in UI, show all candidate values.
+
+### Conflict penalty calculation
+
+```
+total_fields = number of distinct (row, field) pairs across all sources
+conflicting_fields = count where 2+ distinct values exist
+conflict_penalty = min(1.0, conflicting_fields / total_fields)
+```
+
+Apply as multiplier: `final_score = base_score × (1 − conflict_penalty)`.
+
+### Surfacing conflicts in the UI
+
+The widget MUST display conflicts when they exist:
+
+1. Conflict count badge — "3 conflicts detected" near the score
+2. Conflict expansion panel — click to reveal list:
+   ```
+   Field: minor_unit (currency BHD)
+   - SIX Group (T1): 3
+   - datahub.io (T2): 3
+   - some-mirror (T2): 2 ← outlier
+   Resolved to: 3 (T1 majority)
+   ```
+3. Inline markers in data table — small icon next to rows with conflicting fields
+4. Honest score — conflict penalty visible in breakdown
+
+Never hide a conflict by silently picking one value.
+
+### What is NOT a conflict
+- One source has more fields than another → coverage, not conflict
+- One source has fewer rows → coverage
+- Values differing only in formatting → normalise first
+- Source returned an error → fetch failure, exclude from conflict detection
+
+---
+
+## Section 5 — Performance & optimisation
+
+### Target latencies
+
+| Query type | Target |
+|---|---|
+| Cache hit (repeat query) | <50ms |
+| Known topic, sources reachable | 1–2s |
+| Known topic, slow source | 2–3s (short-circuit) |
+| Unknown topic, needs discovery | 4–6s |
+
+### Six optimisations in priority order
+
+1. Parallel fetches — Never serial. Use `Promise.allSettled` (JS) or `asyncio.gather` (Python). `allSettled` is critical — `Promise.all` rejects the whole batch on one 404. 60–75% reduction in fetch time.
+
+2. Query cache with topic-aware TTL:
+
+| Topic class | TTL | Why |
+|---|---|---|
+| ISO standards | 30 days | Updated yearly at most |
+| IANA registries | 7 days | Quarterly updates |
+| Phone calling codes | 30 days | Rarely changes |
+| Address formats | 30 days | Stable |
+| Exchange rates | 5 minutes | Live financial data |
+| Crypto prices | 30 seconds | Volatile |
+
+Don't use flat TTL. Cache key: `hash(query.lower().strip())`.
+
+3. Pre-computed source registry — Tier classification via static lookup in Section 1, NOT LLM call. Microseconds vs 800ms.
+
+4. Known-topic source map — Use Section 2 directly. Skip web search for matched topics. Saves 2–4 seconds.
+
+5. Early-exit short-circuit — If first response is T1, complete, and running score ≥90, stop waiting:
+```
+After each result: if r.tier == 1 AND r.coverage >= 1.0 AND running_score >= 90:
+  cancel pending fetches, return now
+```
+
+6. Streaming UI — Show results as they arrive. Doesn't reduce wall-clock but jumps perceived speed 2–3×.
+
+### What to skip
+- Redis/Postgres (in-memory or SQLite is fine at this scale)
+- WebWorkers (bottleneck is network, not CPU)
+- Response compression (negligible at our data sizes)
+- Predictive pre-fetching (hard to predict, wastes bandwidth)
+
+### Failure handling
+- Set 10s timeout per fetch
+- On timeout: mark source `failed_timeout`, exclude from conflict detection, reduce multiplicity, continue
+- If ALL live sources fail:
+  → Emergency fallback: attempt to read the pre-fetch cache (Section 2-B) ignoring TTL.
+  → If cache has any entry for this topic, serve it with a staleness warning in the widget.
+  → Stale data is always preferable to no data — never silently return empty.
+  → If cache also empty → Section 8 "no trustable source" response.
+
+### Refresh threshold for pre-fetch pipeline
+
+To guarantee the cache is never more than 50% expired when the skill reads it,
+the `prefetch.py` pipeline uses `REFRESH_THRESHOLD = 0.5`. This means it
+refreshes a topic when `cache_age >= 0.5 × TTL`:
+
+| Topic class   | TTL    | Refresh trigger | Recommended cron |
+|---------------|--------|-----------------|------------------|
+| ISO standards | 30 days | 15 days        | weekly `0 2 * * 1` |
+| IANA registry |  7 days |  3.5 days      | daily `0 2 * * *`  |
+| Address fmts  | 30 days | 15 days        | weekly `0 2 * * 1` |
+| Phone codes   | 30 days | 15 days        | weekly `0 2 * * 1` |
+
+One missed daily run never causes a stale-cache fallthrough at 50% threshold.
+
+---
+
+## Section 9.5 — Scoring & Diagnostics Summary
+
+### Purpose
+
+After every run (widget-only or widget + utility), the skill MUST print a
+concise scoring breakdown in the terminal so the user can see exactly how the
+winner was chosen. This is the ONLY permitted prose/text output beyond the
+widget itself.
+
+### When to print
+
+Print this block:
+1. After the widget renders (Step 8.5), on every plain `/utility-creator` run.
+2. After the utility summary table (Section 12, Step D), on utility generation runs.
+
+### How to generate
+
+Run the following bash snippet immediately after Recipe 7 (the winner data
+is already in `/tmp/tsf_result.json`):
+
+```bash
+python3 << 'EOF'
+import json, sys
+with open("/tmp/tsf_result.json") as f:
+    r = json.load(f)
+w = r.get("winner")
+if not w:
+    print("No winner — see error output above.")
+    sys.exit(0)
+
+fac = w.get("factors", {})
+
+def fmt_bar(v, width=20):
+    filled = round(v * width)
+    return "[" + "█" * filled + "░" * (width - filled) + f"] {v:.2f}"
+
+lines = [
+    "",
+    "╔══════════════════════════════════════════════════════════╗",
+    "║           TSF SCORING & DIAGNOSTICS SUMMARY              ║",
+    "╚══════════════════════════════════════════════════════════╝",
+    "",
+    f"  Topic          : {r['topic']}",
+    f"  Winning source : {w['name']}",
+    f"  Source URL     : {w.get('url', 'n/a')}",
+    f"  Tier           : Tier {w['tier']} ({'Official (T1)' if w['tier'] == 1 else 'Official-derived (T2)'})",
+    f"  Rows fetched   : {len(w.get('rows', []))}",
+    f"  From cache     : {r.get('from_cache', False)}",
+    f"  Conflicts      : {r.get('conflict_count', 0)}",
+    "",
+    "  ── Score breakdown (weight × raw value) ──────────────────",
+    "",
+    f"  tier_authority  (×0.35)  {fmt_bar(fac.get('tier_authority', 0))}",
+    f"  multiplicity    (×0.15)  {fmt_bar(fac.get('multiplicity', 0))}",
+    f"  freshness       (×0.15)  {fmt_bar(fac.get('freshness', 0))}",
+    f"  coverage        (×0.15)  {fmt_bar(fac.get('coverage', 0))}",
+    f"  recurrence      (×0.10)  {fmt_bar(fac.get('recurrence', 0))}",
+    f"  independence    (×0.10)  {fmt_bar(fac.get('independence', 0))}",
+    "",
+    f"  conflict_penalty         -{fac.get('conflict_penalty', 0):.2f}  (applied after base)",
+    "",
+    "  ─────────────────────────────────────────────────────────",
+    f"  FINAL ACCURACY SCORE     {w['score']}/100",
+    "═" * 62,
+    "",
+]
+print("\n".join(lines))
+EOF
+```
+
+### Output format rule
+
+The output is a single fenced code block (triple-backtick) printed as
+plain terminal text — not HTML, not a widget. It must appear directly
+after the widget in the response. Do not summarise it in prose; just
+emit the block as-is.
+
+### If `/tmp/tsf_result.json` is missing
+
+Skip the diagnostic block silently and do not error. The widget itself
+already surfaced whatever failure occurred.
+
+---
+
+## Section 7 — Output contract — LIVE WIDGET + SCORING DIAGNOSTIC
+
+Every response MUST output exactly one interactive widget followed by one scoring diagnostic block. Do NOT output:
+- Sources tables in markdown
+- Best API blocks
+- data.json dumps
+- Preamble or summary text
+- Markdown explanations alongside the widget
+
+These are internal working steps, never shown to the user.
+
+**Exception — scoring diagnostic**: After the widget renders, the skill MUST print a single fenced Markdown block (see Section 9.5) that contains the winning source name/URL, tier, final score, and per-factor breakdown. This is the one permitted piece of terminal text output. Everything else in this list remains forbidden.
+
+**Exception — Missing Data Clarification Menu**: If the user's request named specific data fields that are absent from the winning source's output, the skill MUST append the following menu immediately after the Scoring Diagnostic block. Never skip this step silently — surfacing the gap is mandatory.
+
+```
+---
+**Missing Data Notice**
+The authoritative source used for this widget does not track the following requested data: **[list missing fields, e.g., "historical calling codes"]**.
+
+How would you like to proceed?
+- **[1]** This data is sufficient for my needs.
+- **[2]** Run a deep research hunt (Section 13 protocol) specifically to find an authoritative source for the missing fields.
+---
+```
+
+Detection rule: compare the field names the user named in their query against the column list in `/tmp/tsf_parsed.json`. Any named field absent from every source's `columns` array is a missing field and must be listed in the menu.
+
+### The widget MUST include
+- Real fetched data (never placeholders)
+- Accuracy score 0–100 with per-factor breakdown
+- Tier badge for winning source (T1=green, T2=amber)
+- Source URL clearly visible and clickable
+- Conflict report if sources disagreed
+- Filter/search controls for the data
+- Pagination if >50 rows
+
+### Widget HTML template
+
+Use this structure. Replace placeholders with computed values. Embed real data in the JS constants — no runtime API calls inside the widget except where the source provides a live JSON endpoint.
+
+```html
+<style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  .tsf{padding:1rem 0;font-family:var(--font-sans)}
+  .tsf-hdr{display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap;padding:.75rem 0;border-bottom:.5px solid var(--color-border-tertiary);margin-bottom:1rem}
+  .tsf-title{font-size:15px;font-weight:500;color:var(--color-text-primary)}
+  .tsf-source{font-size:12px;color:var(--color-text-secondary);margin-top:3px;font-family:var(--font-mono)}
+  .tsf-source a{color:var(--color-text-info);text-decoration:none;word-break:break-all}
+  .tsf-score{font-size:32px;font-weight:500;font-family:var(--font-mono)}
+  .tsf-score.high{color:var(--color-text-success)}
+  .tsf-score.mid{color:var(--color-text-warning)}
+  .tsf-score.low{color:var(--color-text-danger)}
+  .tsf-tier{font-size:10px;font-weight:500;padding:3px 9px;border-radius:99px;letter-spacing:.5px;font-family:var(--font-mono)}
+  .tsf-tier.t1{background:var(--color-background-success);color:var(--color-text-success)}
+  .tsf-tier.t2{background:var(--color-background-warning);color:var(--color-text-warning)}
+  .tsf-breakdown{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px;margin-bottom:1rem}
+  .tsf-bd{background:var(--color-background-secondary);border-radius:var(--border-radius-md);padding:.6rem .85rem}
+  .tsf-bd-lbl{font-size:10px;color:var(--color-text-secondary);text-transform:uppercase;letter-spacing:.5px;font-family:var(--font-mono);margin-bottom:3px}
+  .tsf-bd-val{font-size:14px;font-weight:500;font-family:var(--font-mono)}
+  .tsf-bd-bar{height:3px;background:var(--color-border-tertiary);border-radius:99px;margin-top:5px;overflow:hidden}
+  .tsf-bd-fill{height:100%;background:var(--color-text-info);border-radius:99px}
+  .tsf-conflict{background:var(--color-background-warning);border-radius:var(--border-radius-md);padding:.7rem .9rem;margin-bottom:1rem;font-size:12px;color:var(--color-text-warning)}
+  .tsf-table{width:100%;border-collapse:collapse;font-family:var(--font-mono);font-size:12px}
+  .tsf-table th{text-align:left;padding:6px 10px;color:var(--color-text-secondary);border-bottom:.5px solid var(--color-border-tertiary);font-weight:500;font-size:10px;text-transform:uppercase;letter-spacing:.6px}
+  .tsf-table td{padding:6px 10px;border-bottom:.5px solid var(--color-border-tertiary);color:var(--color-text-primary)}
+</style>
+
+<div class="tsf">
+  <div class="tsf-hdr">
+    <div>
+      <div class="tsf-title">{TOPIC_TITLE}</div>
+      <div class="tsf-source">source → <a href="{SOURCE_URL}" target="_blank">{SOURCE_NAME}</a></div>
+    </div>
+    <div style="display:flex;align-items:center;gap:12px">
+      <span class="tsf-tier {TIER_CLASS}">TIER {TIER_NUM}</span>
+      <div style="text-align:right">
+        <div class="tsf-score {SCORE_CLASS}">{SCORE}</div>
+        <div style="font-size:10px;color:var(--color-text-secondary);font-family:var(--font-mono);letter-spacing:.6px">ACCURACY / 100</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Per-factor breakdown grid: one .tsf-bd per factor with label, contribution, and progress bar -->
+  <div class="tsf-breakdown"></div>
+
+  <!-- Conflict block renders only if conflicts exist, populated from conflict detection -->
+
+  <input type="text" placeholder="filter rows…" oninput="tsfFilter()"
+         style="padding:7px 10px;border:.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary);font-size:13px;font-family:var(--font-mono);width:100%;margin-bottom:.75rem"/>
+
+  <div id="tsf-table-wrap"></div>
+</div>
+
+<script>
+const ROWS = {ROWS_JSON};
+const COLUMNS = {COLUMNS_JSON};
+const PAGE_SIZE = 50;
+let filtered = ROWS, page = 0;
+
+function render() {
+  const start = page * PAGE_SIZE;
+  const slice = filtered.slice(start, start + PAGE_SIZE);
+  const thead = '<tr>' + COLUMNS.map(c => `<th>${c}</th>`).join('') + '</tr>';
+  const tbody = slice.map(row =>
+    '<tr>' + COLUMNS.map(c => `<td>${row[c] ?? ''}</td>`).join('') + '</tr>'
+  ).join('');
+  let pager = '';
+  if (filtered.length > PAGE_SIZE) {
+    const prev = page > 0 ? `<button onclick="page--;render()">‹ prev</button>` : '';
+    const next = start + PAGE_SIZE < filtered.length ? `<button onclick="page++;render()">next ›</button>` : '';
+    pager = `<div style="margin-top:.5rem;font-size:12px;color:var(--color-text-secondary);display:flex;gap:8px;align-items:center">${prev}<span>${start+1}–${Math.min(start+PAGE_SIZE,filtered.length)} of ${filtered.length}</span>${next}</div>`;
+  }
+  document.getElementById('tsf-table-wrap').innerHTML =
+    `<table class="tsf-table"><thead>${thead}</thead><tbody>${tbody}</tbody></table>${pager}`;
+}
+
+function tsfFilter() {
+  const q = document.querySelector('.tsf input[type=text]').value.toLowerCase();
+  filtered = q
+    ? ROWS.filter(r => COLUMNS.some(c => String(r[c] ?? '').toLowerCase().includes(q)))
+    : ROWS;
+  page = 0;
+  render();
+}
+
+render();
+</script>
+```
+
+---
+
+## Section 8 — When no trustable source exists
+
+If neither T1 nor T2 source exists for the topic, do NOT produce a widget and do NOT fall back to T3. Respond with this exact structure:
+
+```
+## Could not find a trustable source for: [Topic]
+
+Why:
+- Tier 1 check: [what official body would own this, and whether they publish it]
+- Tier 2 check: [what mirrors were looked for, and why none qualified]
+
+What you can do instead:
+Option 1 — [most practical path, e.g. "Download the ITU PDF and extract manually"]
+Option 2 — [alternative path]
+Option 3 — [if applicable, e.g. "Sign up for paywalled official access"]
+
+Note: Tier 3 community sources exist but are not recommended — accuracy cannot be guaranteed without an official reference to verify against.
+```
+
+---
+
+## Section 9 — Edge cases
+
+| Case | Handling |
+|---|---|
+| T1 blocked by domain policy (egress proxy 403) | Try github_mirror URL for that source (Section 2). Tier stays T1 — GitHub is delivery, not authority. If no mirror exists, check pre-fetch cache (Section 2-B). Add widget note: "Served via GitHub mirror — canonical domain blocked by sandbox policy." |
+| T1 blocked and no github_mirror | Check pre-fetch cache (Section 2-B). If cache warm, serve with cache banner. If cache cold, fall through to T2 sources. |
+| All live sources fail, cache is warm but stale | Serve stale cache with staleness warning. Never return empty when stale data exists. |
+| All live sources fail, cache is cold | Section 8 "no trustable source" response. |
+| Mixed-age cache sources (fetched_at delta > 7d) | Add widget warning about unreliable conflict detection. Show re-run command. |
+| T2 source is stale (>5 years) | Use but add freshness warning in widget |
+| Topic is ambiguous (e.g. "payment formats") | Ask ONE clarifying question. Do not guess. |
+| Topic has no standards body | State this. Do not invent a T1 authority. Go to Section 8 response. |
+| User explicitly asks for T3 | Explain why not recommended. Point to T1/T2 alternative. Provide on insistence with warning. |
+| Two T1 sources disagree | Apply Section 4 tie-breaking rules in order. |
+| Sources disagree on a value | Highest-tier value wins. Show all conflicting values side-by-side. Apply conflict penalty. |
+
+---

--- a/.claude/skills/utility-creator/docs/4_ERROR_HANDLING.md
+++ b/.claude/skills/utility-creator/docs/4_ERROR_HANDLING.md
@@ -1,0 +1,83 @@
+# Technical Source Finder — Error Handling
+
+This file is a supplement to the root [`SKILL.md`](../SKILL.md).
+It contains Section 10 (What this skill does NOT do), Section 11 (Error Transparency), and Section 11.5 (Troubleshooting).
+
+---
+
+## Section 10 — What this skill explicitly does NOT do
+
+- Does not use neural networks for ranking. The function is genuinely linear; ML would learn the same weighted sum we hand-wrote, but slower and opaquely. Linear is correct because rules are known, training data doesn't exist, and explainability is mandatory.
+- Does not return T3 sources regardless of star count or popularity
+- Does not output prose explanations alongside the widget
+- Does not fabricate data when a source is unreachable — returns honest "could not find" response
+- Does not psychoanalyse the query or ask multiple clarifying questions
+- Does not use Wikipedia as a primary source for any technical reference (T3 by default)
+- Does not merge in unverified columns from Tier 3 sources just because the Tier 1 source is missing a field the user asked for
+
+---
+
+## Section 11 — Error Transparency
+
+When running any Python script to fetch or cache Tier-1 data, strictly monitor both stdout and stderr.
+
+**The following conditions MUST trigger an immediate halt and raw error display:**
+- The script outputs a tag matching `CACHE_ERROR|<message>` or `ENVELOPE_ERROR|<message>`
+- The script prints a Python `Traceback` to stderr
+- The script exits with a non-zero exit code
+
+**You MUST NOT:**
+- Silently swallow the error and continue to the next step
+- Ignore the error and proceed as if a fallback was tried
+- Vaguely summarise the error (e.g. "the cache was unavailable")
+
+**You MUST:**
+- Immediately halt execution — do not proceed to any further Recipe or step
+- Display the exact, raw error output to the user in a terminal-style code block:
+
+```
+❌ Script error — execution halted
+
+<exact stdout / stderr output here, unmodified>
+
+Fix the issue above before re-running the skill.
+```
+
+**Scope of this rule — what is NOT an error:**
+- `CACHE_MISS` — expected routing token, not an error; continue to Step 4
+- `CACHE_STALE|...` — expected routing token, not an error; continue to Step 4
+- `FETCH_FAILED|<name>` — partial fetch failure; log internally, reduce multiplicity, continue
+- `ALL_FAILED` — all sources failed; trigger emergency cache fallback per Section 6, not this rule
+
+Any token not listed above that signals an unexpected failure (non-zero exit, `Traceback`, `CACHE_ERROR|`, `ENVELOPE_ERROR|`, `PARSE_ERROR|`, `FETCH_ERROR|`, `UTILITY_ERROR|`) falls under this rule and requires an immediate halt and raw display.
+
+---
+
+## Section 11.5 — Troubleshooting
+
+Real errors encountered during development. Symptom → cause → fix.
+
+- **`ENVELOPE_ERROR|[Errno 2] No such file or directory: 'i18nify-data/.../data.json'`**
+  Cause: Recipe 1 returned `CACHE_HIT|LOCAL:…` for a path that doesn't exist yet (topic has never been fetched).
+  Fix: Run `python3 tools/crawlers/crawl4ai_runner.py --topic <name>` to generate the file, then re-run.
+
+- **`RUNNER_FAILED|<topic>|no PARSE_OK in output`**
+  Cause: Crawl4AI Docker container is not running.
+  Fix: `docker run -d -p 11235:11235 unclecode/crawl4ai` then retry Recipe 3.
+
+- **`RUNNER_FAILED|<topic>|exit=1`** with `ConnectionRefusedError` in stderr
+  Cause: Same — Crawl4AI container down. Fix: same as above.
+
+- **Recipe 1 returns `CACHE_HIT|LOCAL:…` for `currency_codes` or `country_codes` even though those files were deleted**
+  Cause: git deleted `i18nify-data/currency/data.json` and `i18nify-data/country/metadata/data.json` (visible in `git status`). The CANONICAL_PATH still lists them, so Recipe 1 would hit `CACHE_MISS` (file not found) and fall through to Recipe 3.
+  Fix: Expected behaviour — Recipe 3 will re-fetch and re-write them.
+
+- **`smoke.sh` exits without `SMOKE_OK` when tld data is stale**
+  Cause: tld_list data is older than 7 days; smoke hits `CACHE_STALE` branch and exits cleanly but does not run Recipes 2–7.
+  Fix: Refresh the data first: `python3 tools/crawlers/crawl4ai_runner.py --topic tld`, then re-run `smoke.sh`.
+
+- **`UTILITY_ERROR|unsupported topic '…' — add a mapping entry in Recipe 8 TOPIC_MAP`**
+  Cause: Topic key resolved in Step 1 isn't in Recipe 8's `TOPIC_MAP` (e.g. a newly added topic from Section 13).
+  Fix: Add the topic to `TOPIC_MAP` in Recipe 8 and `TOPIC_MAP` in Recipe 8-Go following the pattern of existing entries.
+
+---

--- a/.claude/skills/utility-creator/smoke.sh
+++ b/.claude/skills/utility-creator/smoke.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# smoke.sh — verifies the utility-creator pipeline works end-to-end for http_status_codes
+# Run from repo root: bash .claude/skills/utility-creator/smoke.sh
+# Requires: venv present at repo root OR venv activated before running
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+VENV_PY="$REPO_ROOT/venv/bin/python"
+if [ -x "$VENV_PY" ]; then
+  PY="$VENV_PY"
+else
+  PY="python3"
+fi
+
+fail() { echo "SMOKE_FAIL: $1" >&2; exit 1; }
+ok()   { echo "  OK  $1"; }
+
+echo "=== utility-creator smoke test: http_status_codes ==="
+echo "    python: $PY"
+echo ""
+
+# ── Recipe 0 — deps ────────────────────────────────────────────────────────
+echo "[0] Recipe 0 — install deps"
+"$PY" -m pip install requests pyyaml lxml -q 2>&1 | tail -2
+ok "deps installed"
+
+# ── Recipe 1 — check local cache ───────────────────────────────────────────
+echo "[1] Recipe 1 — check local cache"
+R1=$("$PY" << 'PYEOF'
+import os, sys
+from datetime import datetime, timezone
+
+topic = "http_status_codes"
+local_path = "i18nify-data/http-status/data.json"
+ttl = 7
+
+if os.path.exists(local_path):
+    mtime = os.path.getmtime(local_path)
+    age_days = (datetime.now(timezone.utc).timestamp() - mtime) / 86400
+    if age_days <= ttl:
+        print(f"CACHE_HIT|LOCAL:{local_path}|{age_days:.1f}|{ttl}")
+    else:
+        print(f"CACHE_STALE|{age_days:.1f}|{ttl}")
+else:
+    print("CACHE_MISS")
+PYEOF
+)
+echo "    $R1"
+
+ROUTING=$(echo "$R1" | cut -d'|' -f1)
+CACHE_PATH=$(echo "$R1" | cut -d'|' -f2)
+
+if [[ "$ROUTING" == "CACHE_HIT" ]]; then
+  ok "local cache hit"
+elif [[ "$ROUTING" == "CACHE_STALE" ]]; then
+  echo "    WARNING: cache stale — Recipe 3 (crawl4ai live fetch) NOT exercised by this smoke test"
+  echo "    To refresh: python3 tools/crawlers/crawl4ai_runner.py --topic http_status"
+  ok "stale routing detected"
+elif [[ "$ROUTING" == "CACHE_MISS" ]]; then
+  echo "    WARNING: no local data — Recipe 3 (crawl4ai live fetch) NOT exercised by this smoke test"
+  echo "    To populate: python3 tools/crawlers/crawl4ai_runner.py --topic http_status"
+  ok "miss routing detected"
+else
+  fail "Recipe 1 returned unexpected token: $ROUTING"
+fi
+
+# ── Recipe 2 — load cache (only if CACHE_HIT|LOCAL:...) ────────────────────
+if [[ "$ROUTING" == "CACHE_HIT" ]]; then
+  echo "[2] Recipe 2 — load cache envelope"
+  R2=$("$PY" << PYEOF
+import json, sys, os
+from datetime import datetime, timezone
+
+hit_path = "$CACHE_PATH"
+PATH_DATA_KEY = {"i18nify-data/http-status/data.json": "http_status_information"}
+PATH_SOURCE_URL = {"i18nify-data/http-status/data.json": "https://www.iana.org/assignments/http-status-codes/http-status-codes.xml"}
+
+file_path = hit_path[len("LOCAL:"):]
+mtime = os.path.getmtime(file_path)
+fetched_at = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+data_key   = PATH_DATA_KEY.get(file_path, "")
+source_url = PATH_SOURCE_URL.get(file_path, "local")
+
+with open(file_path) as f:
+    canonical = json.load(f)
+
+data_dict = canonical.get(data_key) if data_key else None
+if not data_dict:
+    data_dict = next(iter(canonical.values()), {})
+
+data = [{"cc": k, **v} for k, v in data_dict.items()] if isinstance(data_dict, dict) else []
+
+envelope = {"sources": [{"meta": {"tier": 1, "source_name": source_url,
+    "url_used": source_url, "fetched_at": fetched_at, "via_github": False}, "data": data}]}
+
+with open("/tmp/uc_smoke_cache_data.json", "w") as f:
+    json.dump(envelope, f, ensure_ascii=False)
+print(f"ENVELOPE_OK|rows={len(data)}")
+PYEOF
+  )
+  echo "    $R2"
+  [[ "$R2" == ENVELOPE_OK* ]] || fail "Recipe 2 failed: $R2"
+  ok "envelope loaded"
+
+  # ── Recipe 5 — normalise ─────────────────────────────────────────────────
+  echo "[5] Recipe 5 — normalise"
+  "$PY" << 'PYEOF' > /dev/null || fail "Recipe 5: normalise step exited non-zero"
+import json
+with open("/tmp/uc_smoke_cache_data.json") as f:
+    envelope = json.load(f)
+parsed = []
+for i, src in enumerate(envelope.get("sources", [])):
+    m = src["meta"]; raw = src["data"]
+    rows = raw if isinstance(raw, list) else []
+    cols = list(rows[0].keys()) if rows else []
+    parsed.append({"tier": m["tier"], "name": m["source_name"], "url": m["url_used"],
+        "via_mirror": m["via_github"], "fetched_at": m["fetched_at"],
+        "columns": cols, "rows": rows, "source_type": "prefetch_cache", "from_cache": True})
+with open("/tmp/uc_smoke_parsed.json", "w") as f:
+    json.dump(parsed, f, ensure_ascii=False)
+print(f"CACHE_LOAD_DONE|{len(parsed)}")
+PYEOF
+  ok "data normalised"
+fi
+
+# ── Recipe 6 — score ───────────────────────────────────────────────────────
+echo "[6] Recipe 6 — score"
+PARSED_FILE="/tmp/uc_smoke_parsed.json"
+if [[ ! -f "$PARSED_FILE" ]]; then
+  fail "Recipe 5 did not write /tmp/uc_smoke_parsed.json"
+fi
+
+R6=$("$PY" << PYEOF
+import json, math
+from datetime import datetime, timezone
+
+with open("$PARSED_FILE") as f:
+    sources = json.load(f)
+
+topic = "http_status_codes"; topic_ttl = 7
+from_cache = any(s.get("from_cache") for s in sources)
+cache_freshness = 1.0
+if from_cache:
+    fas = [s.get("fetched_at") for s in sources if s.get("fetched_at")]
+    if fas:
+        oldest = min(datetime.fromisoformat(t) for t in fas)
+        age_d = (datetime.now(timezone.utc) - oldest).total_seconds() / 86400
+        cache_freshness = max(0.5, 1.0 - (age_d / topic_ttl) * 0.5)
+
+expected = 60; n = len(sources)
+scored = []
+for src in sources:
+    ta = 1.0 if src["tier"]==1 else 0.7
+    mult = min(1.0, math.log2(n+1)/3)
+    fresh = cache_freshness if src.get("from_cache") else 0.97
+    cov = min(1.0, len(src.get("rows",[])) / expected)
+    base = 0.35*ta + 0.15*mult + 0.15*fresh + 0.15*cov + 0.10*0.85 + 0.10*1.0
+    scored.append({**src, "score": round(100*base), "factors": {
+        "tier_authority":ta,"multiplicity":mult,"freshness":fresh,
+        "coverage":cov,"recurrence":0.85,"independence":1.0,"conflict_penalty":0}})
+scored.sort(key=lambda s: -s["score"])
+w = scored[0]
+result = {"topic": topic, "winner": w, "all_sources": scored,
+          "conflicts": [], "conflict_count": 0, "from_cache": from_cache, "cache_freshness": cache_freshness}
+with open("/tmp/uc_smoke_result.json","w") as f:
+    json.dump(result, f, ensure_ascii=False)
+print(f"SCORE_DONE|score={w['score']}|tier={w['tier']}|rows={len(w.get('rows',[]))}")
+PYEOF
+)
+echo "    $R6"
+[[ "$R6" == SCORE_DONE* ]] || fail "Recipe 6 failed: $R6"
+ok "scored"
+
+# ── Recipe 7 — extract winner ──────────────────────────────────────────────
+echo "[7] Recipe 7 — extract winner"
+"$PY" -c "
+import json
+with open('/tmp/uc_smoke_result.json') as f:
+    r = json.load(f)
+w = r['winner']
+assert w['score'] > 0, 'score must be > 0'
+assert len(w.get('rows', [])) >= 60, f'expected >=60 HTTP status rows, got {len(w.get(\"rows\", []))}'
+print(f\"  topic={r['topic']} score={w['score']} rows={len(w.get('rows',[]))} tier={w['tier']}\")
+"
+ok "winner extracted"
+
+# ── Cleanup ────────────────────────────────────────────────────────────────
+rm -f /tmp/uc_smoke_cache_data.json /tmp/uc_smoke_parsed.json /tmp/uc_smoke_result.json
+
+echo ""
+echo "SMOKE_OK|http_status_codes|pipeline verified end-to-end"


### PR DESCRIPTION
## Summary

- Adds `utility-creator` Claude Code skill for scaffolding new i18nify utility modules
- Adds `fetcher` and `validator` agents, `/fetch-data` and `/status` commands
- Internal developer tooling only — does not affect published packages

## Test plan

- [ ] `bash .claude/skills/utility-creator/smoke.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)