### PR TITLE
fix(address): normalize languages field to always be string array

### DIFF
--- a/i18nify-data/address/data.json
+++ b/i18nify-data/address/data.json
@@ -9,7 +9,9 @@
     "AD": {
       "country_name": "ANDORRA",
       "lang": "ca",
-      "languages": "ca",
+      "languages": [
+        "ca"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C",
       "zip_regex": "AD[1-7]0\\d",
       "zip_example": "AD100,AD501,AD700",
@@ -45,7 +47,9 @@
     "AE": {
       "country_name": "UNITED ARAB EMIRATES",
       "lang": "ar",
-      "languages": "ar",
+      "languages": [
+        "ar"
+      ],
       "fmt": "%N%n%O%n%A%n%S",
       "require": "AS",
       "state_name_type": "emirate",
@@ -102,7 +106,9 @@
     "AM": {
       "country_name": "ARMENIA",
       "lang": "hy",
-      "languages": "hy",
+      "languages": [
+        "hy"
+      ],
       "fmt": "%N%n%O%n%A%n%Z%n%C%n%S",
       "zip_regex": "(?:37)?\\d{4}",
       "zip_example": "375010,0002,0010",
@@ -142,7 +148,9 @@
     "AR": {
       "country_name": "ARGENTINA",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C%n%S",
       "zip_regex": "((?:[A-HJ-NP-Z])?\\d{4})([A-Z]{3})?",
       "zip_example": "C1070AAM,C1000WAM,B1000TBU,X5187XAB",
@@ -247,7 +255,9 @@
     "AU": {
       "country_name": "AUSTRALIA",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%O%n%N%n%A%n%C %S %Z",
       "require": "ACSZ",
       "zip_regex": "\\d{4}",
@@ -388,7 +398,9 @@
     "BR": {
       "country_name": "BRAZIL",
       "lang": "pt",
-      "languages": "pt",
+      "languages": [
+        "pt"
+      ],
       "fmt": "%O%n%N%n%A%n%D%n%C-%S%n%Z",
       "require": "ASCZ",
       "zip_regex": "\\d{5}-?\\d{3}",
@@ -487,7 +499,9 @@
     "BS": {
       "country_name": "BAHAMAS",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%C, %S",
       "state_name_type": "island",
       "sub_keys": [
@@ -668,7 +682,9 @@
     "CL": {
       "country_name": "CHILE",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C%n%S",
       "zip_regex": "\\d{7}",
       "zip_example": "8340457,8720019,1230000,8329100",
@@ -734,7 +750,9 @@
     "CN": {
       "country_name": "CHINA",
       "lang": "zh",
-      "languages": "zh",
+      "languages": [
+        "zh"
+      ],
       "fmt": "%Z%n%S%C%D%n%A%n%O%n%N",
       "require": "ACSZ",
       "zip_regex": "\\d{6}",
@@ -853,7 +871,9 @@
     "CO": {
       "country_name": "COLOMBIA",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%D%n%C, %S, %Z",
       "require": "AS",
       "zip_regex": "\\d{6}",
@@ -942,7 +962,9 @@
     "CU": {
       "country_name": "CUBA",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%C %S%n%Z",
       "zip_regex": "\\d{5}",
       "zip_example": "10700",
@@ -986,7 +1008,9 @@
     "CV": {
       "country_name": "CAPE VERDE",
       "lang": "pt",
-      "languages": "pt",
+      "languages": [
+        "pt"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C%n%S",
       "zip_regex": "\\d{4}",
       "zip_example": "7600",
@@ -1090,7 +1114,9 @@
     "EG": {
       "country_name": "EGYPT",
       "lang": "ar",
-      "languages": "ar",
+      "languages": [
+        "ar"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S%n%Z",
       "zip_regex": "\\d{5}",
       "zip_example": "12411,11599",
@@ -1508,7 +1534,9 @@
     "ID": {
       "country_name": "INDONESIA",
       "lang": "id",
-      "languages": "id",
+      "languages": [
+        "id"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S %Z",
       "require": "AS",
       "zip_regex": "\\d{5}",
@@ -1589,7 +1617,9 @@
     "IE": {
       "country_name": "IRELAND",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%D%n%C%n%S%n%Z",
       "zip_regex": "[\\dA-Z]{3} ?[\\dA-Z]{4}",
       "zip_example": "A65 F4E2",
@@ -1815,7 +1845,9 @@
     "IR": {
       "country_name": "IRAN",
       "lang": "fa",
-      "languages": "fa",
+      "languages": [
+        "fa"
+      ],
       "fmt": "%O%n%N%n%S%n%C, %D%n%A%n%Z",
       "zip_regex": "\\d{5}-?\\d{5}",
       "zip_example": "11936-12345",
@@ -1897,7 +1929,9 @@
     "IT": {
       "country_name": "ITALY",
       "lang": "it",
-      "languages": "it",
+      "languages": [
+        "it"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C %S",
       "require": "ACSZ",
       "zip_regex": "\\d{5}",
@@ -2242,7 +2276,9 @@
     "JM": {
       "country_name": "JAMAICA",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S %X",
       "require": "ACS",
       "state_name_type": "parish",
@@ -2288,7 +2324,9 @@
     "JP": {
       "country_name": "JAPAN",
       "lang": "ja",
-      "languages": "ja",
+      "languages": [
+        "ja"
+      ],
       "fmt": "〒%Z%n%S%n%A%n%O%n%N",
       "require": "ASZ",
       "zip_regex": "\\d{3}-?\\d{4}",
@@ -2424,7 +2462,9 @@
     "KN": {
       "country_name": "SAINT KITTS AND NEVIS",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%C, %S",
       "require": "ACS",
       "state_name_type": "island",
@@ -2440,7 +2480,9 @@
     "KP": {
       "country_name": "NORTH KOREA",
       "lang": "ko",
-      "languages": "ko",
+      "languages": [
+        "ko"
+      ],
       "fmt": "%Z%n%S%n%C%n%A%n%O%n%N",
       "sub_keys": [
         "강원도",
@@ -2472,7 +2514,9 @@
     "KR": {
       "country_name": "SOUTH KOREA",
       "lang": "ko",
-      "languages": "ko",
+      "languages": [
+        "ko"
+      ],
       "fmt": "%S %C%D%n%A%n%O%n%N%n%Z",
       "require": "ACSZ",
       "zip_regex": "\\d{5}",
@@ -2547,7 +2591,9 @@
     "KY": {
       "country_name": "CAYMAN ISLANDS",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%S %Z",
       "require": "AS",
       "zip_regex": "KY\\d-\\d{4}",
@@ -2761,7 +2807,9 @@
     "MX": {
       "country_name": "MEXICO",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%D%n%Z %C, %S",
       "require": "ACSZ",
       "zip_regex": "\\d{5}",
@@ -2875,7 +2923,9 @@
     "MY": {
       "country_name": "MALAYSIA",
       "lang": "ms",
-      "languages": "ms",
+      "languages": [
+        "ms"
+      ],
       "fmt": "%N%n%O%n%A%n%D%n%Z %C%n%S",
       "require": "ACZ",
       "zip_regex": "\\d{5}",
@@ -2923,7 +2973,9 @@
     "MZ": {
       "country_name": "MOZAMBIQUE",
       "lang": "pt",
-      "languages": "pt",
+      "languages": [
+        "pt"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C%S",
       "zip_regex": "\\d{4}",
       "zip_example": "1102,1119,3212",
@@ -2983,7 +3035,9 @@
     "NG": {
       "country_name": "NIGERIA",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%D%n%C %Z%n%S",
       "zip_regex": "\\d{6}",
       "zip_example": "930283,300001,931104",
@@ -3071,7 +3125,9 @@
     "NI": {
       "country_name": "NICARAGUA",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%Z%n%C, %S",
       "zip_regex": "\\d{5}",
       "zip_example": "52000",
@@ -3143,7 +3199,9 @@
     "NR": {
       "country_name": "NAURU CENTRAL PACIFIC",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%S",
       "require": "AS",
       "state_name_type": "district",
@@ -3204,7 +3262,9 @@
     "PE": {
       "country_name": "PERU",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%C %Z%n%S",
       "zip_regex": "(?:LIMA \\d{1,2}|CALLAO 0?\\d)|[0-2]\\d{4}",
       "zip_example": "LIMA 23,LIMA 42,CALLAO 2,02001",
@@ -3285,7 +3345,9 @@
     "PH": {
       "country_name": "PHILIPPINES",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%D, %C%n%Z %S",
       "zip_regex": "\\d{4}",
       "zip_example": "1008,1050,1135,1207,2000,1000",
@@ -3553,7 +3615,9 @@
     "RU": {
       "country_name": "RUSSIAN FEDERATION",
       "lang": "ru",
-      "languages": "ru",
+      "languages": [
+        "ru"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S%n%Z",
       "require": "ACSZ",
       "zip_regex": "\\d{6}",
@@ -3913,7 +3977,9 @@
     "SO": {
       "country_name": "SOMALIA",
       "lang": "so",
-      "languages": "so",
+      "languages": [
+        "so"
+      ],
       "fmt": "%N%n%O%n%A%n%C, %S %Z",
       "require": "ACS",
       "zip_regex": "[A-Z]{2} ?\\d{5}",
@@ -3982,7 +4048,9 @@
     "SR": {
       "country_name": "SURINAME",
       "lang": "nl",
-      "languages": "nl",
+      "languages": [
+        "nl"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S",
       "sub_keys": [
         "Brokopondo",
@@ -4018,7 +4086,9 @@
     "SV": {
       "country_name": "EL SALVADOR",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%Z-%C%n%S",
       "require": "ACS",
       "zip_regex": "CP [1-3][1-7][0-2]\\d",
@@ -4111,7 +4181,9 @@
     "TH": {
       "country_name": "THAILAND",
       "lang": "th",
-      "languages": "th",
+      "languages": [
+        "th"
+      ],
       "fmt": "%N%n%O%n%A%n%D %C%n%S %Z",
       "zip_regex": "\\d{5}",
       "zip_example": "10150,10210",
@@ -4305,7 +4377,9 @@
     "TR": {
       "country_name": "TURKEY",
       "lang": "tr",
-      "languages": "tr",
+      "languages": [
+        "tr"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C/%S",
       "require": "ACZ",
       "zip_regex": "\\d{5}",
@@ -4485,7 +4559,9 @@
     "TV": {
       "country_name": "TUVALU",
       "lang": "tyv",
-      "languages": "tyv",
+      "languages": [
+        "tyv"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S",
       "state_name_type": "island",
       "sub_keys": [
@@ -4514,7 +4590,9 @@
     "TW": {
       "country_name": "TAIWAN",
       "lang": "zh-Hant",
-      "languages": "zh-Hant",
+      "languages": [
+        "zh-Hant"
+      ],
       "fmt": "%Z%n%S%C%n%A%n%O%n%N",
       "require": "ACSZ",
       "zip_regex": "\\d{3}(?:\\d{2,3})?",
@@ -4580,7 +4658,9 @@
     "UA": {
       "country_name": "UKRAINE",
       "lang": "uk",
-      "languages": "uk",
+      "languages": [
+        "uk"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S%n%Z",
       "require": "ACZ",
       "zip_regex": "\\d{5}",
@@ -4691,7 +4771,9 @@
     "US": {
       "country_name": "UNITED STATES",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%C, %S %Z",
       "require": "ACSZ",
       "zip_regex": "(\\d{5})(?:[ \\-](\\d{4}))?",
@@ -4895,7 +4977,9 @@
     "UY": {
       "country_name": "URUGUAY",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C %S",
       "zip_regex": "\\d{5}",
       "zip_example": "11600",
@@ -4966,7 +5050,9 @@
     "VE": {
       "country_name": "VENEZUELA",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%C %Z, %S",
       "require": "ACS",
       "zip_regex": "\\d{4}",
@@ -5048,7 +5134,9 @@
     "VN": {
       "country_name": "VIET NAM",
       "lang": "vi",
-      "languages": "vi",
+      "languages": [
+        "vi"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S %Z",
       "zip_regex": "\\d{5}\\d?",
       "zip_example": "70010,55999",

--- a/i18nify-data/address/proto/address.proto
+++ b/i18nify-data/address/proto/address.proto
@@ -15,7 +15,7 @@ message AddressInfo {
   string zip_regex = 3;
   string zip_example = 4;
   string lang = 5;
-  string languages = 6;
+  repeated string languages = 6;
   string post_url = 7;
   repeated string sub_keys = 8;
   repeated string sub_names = 9;

--- a/i18nify-data/go/address/address.pb.go
+++ b/i18nify-data/go/address/address.pb.go
@@ -22,7 +22,7 @@ type AddressInfo struct {
 	ZipRegex string `json:"zip_regex,omitempty"`
 	ZipExample string `json:"zip_example,omitempty"`
 	Lang string `json:"lang,omitempty"`
-	Languages string `json:"languages,omitempty"`
+	Languages []string `json:"languages,omitempty"`
 	PostUrl string `json:"post_url,omitempty"`
 	SubKeys []string `json:"sub_keys,omitempty"`
 	SubNames []string `json:"sub_names,omitempty"`
@@ -69,11 +69,11 @@ func (x *AddressInfo) GetLang() string {
 	return ""
 }
 
-func (x *AddressInfo) GetLanguages() string {
+func (x *AddressInfo) GetLanguages() []string {
 	if x != nil {
 		return x.Languages
 	}
-	return ""
+	return nil
 }
 
 func (x *AddressInfo) GetPostUrl() string {

--- a/i18nify-data/go/address/data/data.json
+++ b/i18nify-data/go/address/data/data.json
@@ -9,7 +9,9 @@
     "AD": {
       "country_name": "ANDORRA",
       "lang": "ca",
-      "languages": "ca",
+      "languages": [
+        "ca"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C",
       "zip_regex": "AD[1-7]0\\d",
       "zip_example": "AD100,AD501,AD700",
@@ -45,7 +47,9 @@
     "AE": {
       "country_name": "UNITED ARAB EMIRATES",
       "lang": "ar",
-      "languages": "ar",
+      "languages": [
+        "ar"
+      ],
       "fmt": "%N%n%O%n%A%n%S",
       "require": "AS",
       "state_name_type": "emirate",
@@ -102,7 +106,9 @@
     "AM": {
       "country_name": "ARMENIA",
       "lang": "hy",
-      "languages": "hy",
+      "languages": [
+        "hy"
+      ],
       "fmt": "%N%n%O%n%A%n%Z%n%C%n%S",
       "zip_regex": "(?:37)?\\d{4}",
       "zip_example": "375010,0002,0010",
@@ -142,7 +148,9 @@
     "AR": {
       "country_name": "ARGENTINA",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C%n%S",
       "zip_regex": "((?:[A-HJ-NP-Z])?\\d{4})([A-Z]{3})?",
       "zip_example": "C1070AAM,C1000WAM,B1000TBU,X5187XAB",
@@ -247,7 +255,9 @@
     "AU": {
       "country_name": "AUSTRALIA",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%O%n%N%n%A%n%C %S %Z",
       "require": "ACSZ",
       "zip_regex": "\\d{4}",
@@ -388,7 +398,9 @@
     "BR": {
       "country_name": "BRAZIL",
       "lang": "pt",
-      "languages": "pt",
+      "languages": [
+        "pt"
+      ],
       "fmt": "%O%n%N%n%A%n%D%n%C-%S%n%Z",
       "require": "ASCZ",
       "zip_regex": "\\d{5}-?\\d{3}",
@@ -487,7 +499,9 @@
     "BS": {
       "country_name": "BAHAMAS",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%C, %S",
       "state_name_type": "island",
       "sub_keys": [
@@ -668,7 +682,9 @@
     "CL": {
       "country_name": "CHILE",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C%n%S",
       "zip_regex": "\\d{7}",
       "zip_example": "8340457,8720019,1230000,8329100",
@@ -734,7 +750,9 @@
     "CN": {
       "country_name": "CHINA",
       "lang": "zh",
-      "languages": "zh",
+      "languages": [
+        "zh"
+      ],
       "fmt": "%Z%n%S%C%D%n%A%n%O%n%N",
       "require": "ACSZ",
       "zip_regex": "\\d{6}",
@@ -853,7 +871,9 @@
     "CO": {
       "country_name": "COLOMBIA",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%D%n%C, %S, %Z",
       "require": "AS",
       "zip_regex": "\\d{6}",
@@ -942,7 +962,9 @@
     "CU": {
       "country_name": "CUBA",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%C %S%n%Z",
       "zip_regex": "\\d{5}",
       "zip_example": "10700",
@@ -986,7 +1008,9 @@
     "CV": {
       "country_name": "CAPE VERDE",
       "lang": "pt",
-      "languages": "pt",
+      "languages": [
+        "pt"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C%n%S",
       "zip_regex": "\\d{4}",
       "zip_example": "7600",
@@ -1090,7 +1114,9 @@
     "EG": {
       "country_name": "EGYPT",
       "lang": "ar",
-      "languages": "ar",
+      "languages": [
+        "ar"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S%n%Z",
       "zip_regex": "\\d{5}",
       "zip_example": "12411,11599",
@@ -1508,7 +1534,9 @@
     "ID": {
       "country_name": "INDONESIA",
       "lang": "id",
-      "languages": "id",
+      "languages": [
+        "id"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S %Z",
       "require": "AS",
       "zip_regex": "\\d{5}",
@@ -1589,7 +1617,9 @@
     "IE": {
       "country_name": "IRELAND",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%D%n%C%n%S%n%Z",
       "zip_regex": "[\\dA-Z]{3} ?[\\dA-Z]{4}",
       "zip_example": "A65 F4E2",
@@ -1815,7 +1845,9 @@
     "IR": {
       "country_name": "IRAN",
       "lang": "fa",
-      "languages": "fa",
+      "languages": [
+        "fa"
+      ],
       "fmt": "%O%n%N%n%S%n%C, %D%n%A%n%Z",
       "zip_regex": "\\d{5}-?\\d{5}",
       "zip_example": "11936-12345",
@@ -1897,7 +1929,9 @@
     "IT": {
       "country_name": "ITALY",
       "lang": "it",
-      "languages": "it",
+      "languages": [
+        "it"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C %S",
       "require": "ACSZ",
       "zip_regex": "\\d{5}",
@@ -2242,7 +2276,9 @@
     "JM": {
       "country_name": "JAMAICA",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S %X",
       "require": "ACS",
       "state_name_type": "parish",
@@ -2288,7 +2324,9 @@
     "JP": {
       "country_name": "JAPAN",
       "lang": "ja",
-      "languages": "ja",
+      "languages": [
+        "ja"
+      ],
       "fmt": "〒%Z%n%S%n%A%n%O%n%N",
       "require": "ASZ",
       "zip_regex": "\\d{3}-?\\d{4}",
@@ -2424,7 +2462,9 @@
     "KN": {
       "country_name": "SAINT KITTS AND NEVIS",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%C, %S",
       "require": "ACS",
       "state_name_type": "island",
@@ -2440,7 +2480,9 @@
     "KP": {
       "country_name": "NORTH KOREA",
       "lang": "ko",
-      "languages": "ko",
+      "languages": [
+        "ko"
+      ],
       "fmt": "%Z%n%S%n%C%n%A%n%O%n%N",
       "sub_keys": [
         "강원도",
@@ -2472,7 +2514,9 @@
     "KR": {
       "country_name": "SOUTH KOREA",
       "lang": "ko",
-      "languages": "ko",
+      "languages": [
+        "ko"
+      ],
       "fmt": "%S %C%D%n%A%n%O%n%N%n%Z",
       "require": "ACSZ",
       "zip_regex": "\\d{5}",
@@ -2547,7 +2591,9 @@
     "KY": {
       "country_name": "CAYMAN ISLANDS",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%S %Z",
       "require": "AS",
       "zip_regex": "KY\\d-\\d{4}",
@@ -2761,7 +2807,9 @@
     "MX": {
       "country_name": "MEXICO",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%D%n%Z %C, %S",
       "require": "ACSZ",
       "zip_regex": "\\d{5}",
@@ -2875,7 +2923,9 @@
     "MY": {
       "country_name": "MALAYSIA",
       "lang": "ms",
-      "languages": "ms",
+      "languages": [
+        "ms"
+      ],
       "fmt": "%N%n%O%n%A%n%D%n%Z %C%n%S",
       "require": "ACZ",
       "zip_regex": "\\d{5}",
@@ -2923,7 +2973,9 @@
     "MZ": {
       "country_name": "MOZAMBIQUE",
       "lang": "pt",
-      "languages": "pt",
+      "languages": [
+        "pt"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C%S",
       "zip_regex": "\\d{4}",
       "zip_example": "1102,1119,3212",
@@ -2983,7 +3035,9 @@
     "NG": {
       "country_name": "NIGERIA",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%D%n%C %Z%n%S",
       "zip_regex": "\\d{6}",
       "zip_example": "930283,300001,931104",
@@ -3071,7 +3125,9 @@
     "NI": {
       "country_name": "NICARAGUA",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%Z%n%C, %S",
       "zip_regex": "\\d{5}",
       "zip_example": "52000",
@@ -3143,7 +3199,9 @@
     "NR": {
       "country_name": "NAURU CENTRAL PACIFIC",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%S",
       "require": "AS",
       "state_name_type": "district",
@@ -3204,7 +3262,9 @@
     "PE": {
       "country_name": "PERU",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%C %Z%n%S",
       "zip_regex": "(?:LIMA \\d{1,2}|CALLAO 0?\\d)|[0-2]\\d{4}",
       "zip_example": "LIMA 23,LIMA 42,CALLAO 2,02001",
@@ -3285,7 +3345,9 @@
     "PH": {
       "country_name": "PHILIPPINES",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%D, %C%n%Z %S",
       "zip_regex": "\\d{4}",
       "zip_example": "1008,1050,1135,1207,2000,1000",
@@ -3553,7 +3615,9 @@
     "RU": {
       "country_name": "RUSSIAN FEDERATION",
       "lang": "ru",
-      "languages": "ru",
+      "languages": [
+        "ru"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S%n%Z",
       "require": "ACSZ",
       "zip_regex": "\\d{6}",
@@ -3913,7 +3977,9 @@
     "SO": {
       "country_name": "SOMALIA",
       "lang": "so",
-      "languages": "so",
+      "languages": [
+        "so"
+      ],
       "fmt": "%N%n%O%n%A%n%C, %S %Z",
       "require": "ACS",
       "zip_regex": "[A-Z]{2} ?\\d{5}",
@@ -3982,7 +4048,9 @@
     "SR": {
       "country_name": "SURINAME",
       "lang": "nl",
-      "languages": "nl",
+      "languages": [
+        "nl"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S",
       "sub_keys": [
         "Brokopondo",
@@ -4018,7 +4086,9 @@
     "SV": {
       "country_name": "EL SALVADOR",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%Z-%C%n%S",
       "require": "ACS",
       "zip_regex": "CP [1-3][1-7][0-2]\\d",
@@ -4111,7 +4181,9 @@
     "TH": {
       "country_name": "THAILAND",
       "lang": "th",
-      "languages": "th",
+      "languages": [
+        "th"
+      ],
       "fmt": "%N%n%O%n%A%n%D %C%n%S %Z",
       "zip_regex": "\\d{5}",
       "zip_example": "10150,10210",
@@ -4305,7 +4377,9 @@
     "TR": {
       "country_name": "TURKEY",
       "lang": "tr",
-      "languages": "tr",
+      "languages": [
+        "tr"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C/%S",
       "require": "ACZ",
       "zip_regex": "\\d{5}",
@@ -4485,7 +4559,9 @@
     "TV": {
       "country_name": "TUVALU",
       "lang": "tyv",
-      "languages": "tyv",
+      "languages": [
+        "tyv"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S",
       "state_name_type": "island",
       "sub_keys": [
@@ -4514,7 +4590,9 @@
     "TW": {
       "country_name": "TAIWAN",
       "lang": "zh-Hant",
-      "languages": "zh-Hant",
+      "languages": [
+        "zh-Hant"
+      ],
       "fmt": "%Z%n%S%C%n%A%n%O%n%N",
       "require": "ACSZ",
       "zip_regex": "\\d{3}(?:\\d{2,3})?",
@@ -4580,7 +4658,9 @@
     "UA": {
       "country_name": "UKRAINE",
       "lang": "uk",
-      "languages": "uk",
+      "languages": [
+        "uk"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S%n%Z",
       "require": "ACZ",
       "zip_regex": "\\d{5}",
@@ -4691,7 +4771,9 @@
     "US": {
       "country_name": "UNITED STATES",
       "lang": "en",
-      "languages": "en",
+      "languages": [
+        "en"
+      ],
       "fmt": "%N%n%O%n%A%n%C, %S %Z",
       "require": "ACSZ",
       "zip_regex": "(\\d{5})(?:[ \\-](\\d{4}))?",
@@ -4895,7 +4977,9 @@
     "UY": {
       "country_name": "URUGUAY",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%Z %C %S",
       "zip_regex": "\\d{5}",
       "zip_example": "11600",
@@ -4966,7 +5050,9 @@
     "VE": {
       "country_name": "VENEZUELA",
       "lang": "es",
-      "languages": "es",
+      "languages": [
+        "es"
+      ],
       "fmt": "%N%n%O%n%A%n%C %Z, %S",
       "require": "ACS",
       "zip_regex": "\\d{4}",
@@ -5048,7 +5134,9 @@
     "VN": {
       "country_name": "VIET NAM",
       "lang": "vi",
-      "languages": "vi",
+      "languages": [
+        "vi"
+      ],
       "fmt": "%N%n%O%n%A%n%C%n%S %Z",
       "zip_regex": "\\d{5}\\d?",
       "zip_example": "70010,55999",

--- a/packages/i18nify-go/modules/address/address.go
+++ b/packages/i18nify-go/modules/address/address.go
@@ -15,7 +15,7 @@ type AddressInfo struct {
 	ZipRegex string `json:"zip_regex"`
 	ZipExample string `json:"zip_example"`
 	Lang string `json:"lang"`
-	Languages string `json:"languages"`
+	Languages []string `json:"languages"`
 	PostUrl string `json:"post_url"`
 	SubKeys []string `json:"sub_keys"`
 	SubNames []string `json:"sub_names"`

--- a/packages/i18nify-js/src/modules/address/data/addressConfig.json
+++ b/packages/i18nify-js/src/modules/address/data/addressConfig.json
@@ -8,7 +8,9 @@
   "AD": {
     "country_name": "ANDORRA",
     "lang": "ca",
-    "languages": "ca",
+    "languages": [
+      "ca"
+    ],
     "fmt": "%N%n%O%n%A%n%Z %C",
     "zip_regex": "AD[1-7]0\\d",
     "zip_example": "AD100,AD501,AD700",
@@ -44,7 +46,9 @@
   "AE": {
     "country_name": "UNITED ARAB EMIRATES",
     "lang": "ar",
-    "languages": "ar",
+    "languages": [
+      "ar"
+    ],
     "fmt": "%N%n%O%n%A%n%S",
     "require": "AS",
     "state_name_type": "emirate",
@@ -101,7 +105,9 @@
   "AM": {
     "country_name": "ARMENIA",
     "lang": "hy",
-    "languages": "hy",
+    "languages": [
+      "hy"
+    ],
     "fmt": "%N%n%O%n%A%n%Z%n%C%n%S",
     "zip_regex": "(?:37)?\\d{4}",
     "zip_example": "375010,0002,0010",
@@ -141,7 +147,9 @@
   "AR": {
     "country_name": "ARGENTINA",
     "lang": "es",
-    "languages": "es",
+    "languages": [
+      "es"
+    ],
     "fmt": "%N%n%O%n%A%n%Z %C%n%S",
     "zip_regex": "((?:[A-HJ-NP-Z])?\\d{4})([A-Z]{3})?",
     "zip_example": "C1070AAM,C1000WAM,B1000TBU,X5187XAB",
@@ -246,7 +254,9 @@
   "AU": {
     "country_name": "AUSTRALIA",
     "lang": "en",
-    "languages": "en",
+    "languages": [
+      "en"
+    ],
     "fmt": "%O%n%N%n%A%n%C %S %Z",
     "require": "ACSZ",
     "zip_regex": "\\d{4}",
@@ -387,7 +397,9 @@
   "BR": {
     "country_name": "BRAZIL",
     "lang": "pt",
-    "languages": "pt",
+    "languages": [
+      "pt"
+    ],
     "fmt": "%O%n%N%n%A%n%D%n%C-%S%n%Z",
     "require": "ASCZ",
     "zip_regex": "\\d{5}-?\\d{3}",
@@ -486,7 +498,9 @@
   "BS": {
     "country_name": "BAHAMAS",
     "lang": "en",
-    "languages": "en",
+    "languages": [
+      "en"
+    ],
     "fmt": "%N%n%O%n%A%n%C, %S",
     "state_name_type": "island",
     "sub_keys": [
@@ -667,7 +681,9 @@
   "CL": {
     "country_name": "CHILE",
     "lang": "es",
-    "languages": "es",
+    "languages": [
+      "es"
+    ],
     "fmt": "%N%n%O%n%A%n%Z %C%n%S",
     "zip_regex": "\\d{7}",
     "zip_example": "8340457,8720019,1230000,8329100",
@@ -733,7 +749,9 @@
   "CN": {
     "country_name": "CHINA",
     "lang": "zh",
-    "languages": "zh",
+    "languages": [
+      "zh"
+    ],
     "fmt": "%Z%n%S%C%D%n%A%n%O%n%N",
     "require": "ACSZ",
     "zip_regex": "\\d{6}",
@@ -852,7 +870,9 @@
   "CO": {
     "country_name": "COLOMBIA",
     "lang": "es",
-    "languages": "es",
+    "languages": [
+      "es"
+    ],
     "fmt": "%N%n%O%n%A%n%D%n%C, %S, %Z",
     "require": "AS",
     "zip_regex": "\\d{6}",
@@ -941,7 +961,9 @@
   "CU": {
     "country_name": "CUBA",
     "lang": "es",
-    "languages": "es",
+    "languages": [
+      "es"
+    ],
     "fmt": "%N%n%O%n%A%n%C %S%n%Z",
     "zip_regex": "\\d{5}",
     "zip_example": "10700",
@@ -985,7 +1007,9 @@
   "CV": {
     "country_name": "CAPE VERDE",
     "lang": "pt",
-    "languages": "pt",
+    "languages": [
+      "pt"
+    ],
     "fmt": "%N%n%O%n%A%n%Z %C%n%S",
     "zip_regex": "\\d{4}",
     "zip_example": "7600",
@@ -1089,7 +1113,9 @@
   "EG": {
     "country_name": "EGYPT",
     "lang": "ar",
-    "languages": "ar",
+    "languages": [
+      "ar"
+    ],
     "fmt": "%N%n%O%n%A%n%C%n%S%n%Z",
     "zip_regex": "\\d{5}",
     "zip_example": "12411,11599",
@@ -1507,7 +1533,9 @@
   "ID": {
     "country_name": "INDONESIA",
     "lang": "id",
-    "languages": "id",
+    "languages": [
+      "id"
+    ],
     "fmt": "%N%n%O%n%A%n%C%n%S %Z",
     "require": "AS",
     "zip_regex": "\\d{5}",
@@ -1588,7 +1616,9 @@
   "IE": {
     "country_name": "IRELAND",
     "lang": "en",
-    "languages": "en",
+    "languages": [
+      "en"
+    ],
     "fmt": "%N%n%O%n%A%n%D%n%C%n%S%n%Z",
     "zip_regex": "[\\dA-Z]{3} ?[\\dA-Z]{4}",
     "zip_example": "A65 F4E2",
@@ -1814,7 +1844,9 @@
   "IR": {
     "country_name": "IRAN",
     "lang": "fa",
-    "languages": "fa",
+    "languages": [
+      "fa"
+    ],
     "fmt": "%O%n%N%n%S%n%C, %D%n%A%n%Z",
     "zip_regex": "\\d{5}-?\\d{5}",
     "zip_example": "11936-12345",
@@ -1896,7 +1928,9 @@
   "IT": {
     "country_name": "ITALY",
     "lang": "it",
-    "languages": "it",
+    "languages": [
+      "it"
+    ],
     "fmt": "%N%n%O%n%A%n%Z %C %S",
     "require": "ACSZ",
     "zip_regex": "\\d{5}",
@@ -2241,7 +2275,9 @@
   "JM": {
     "country_name": "JAMAICA",
     "lang": "en",
-    "languages": "en",
+    "languages": [
+      "en"
+    ],
     "fmt": "%N%n%O%n%A%n%C%n%S %X",
     "require": "ACS",
     "state_name_type": "parish",
@@ -2287,7 +2323,9 @@
   "JP": {
     "country_name": "JAPAN",
     "lang": "ja",
-    "languages": "ja",
+    "languages": [
+      "ja"
+    ],
     "fmt": "〒%Z%n%S%n%A%n%O%n%N",
     "require": "ASZ",
     "zip_regex": "\\d{3}-?\\d{4}",
@@ -2423,7 +2461,9 @@
   "KN": {
     "country_name": "SAINT KITTS AND NEVIS",
     "lang": "en",
-    "languages": "en",
+    "languages": [
+      "en"
+    ],
     "fmt": "%N%n%O%n%A%n%C, %S",
     "require": "ACS",
     "state_name_type": "island",
@@ -2439,7 +2479,9 @@
   "KP": {
     "country_name": "NORTH KOREA",
     "lang": "ko",
-    "languages": "ko",
+    "languages": [
+      "ko"
+    ],
     "fmt": "%Z%n%S%n%C%n%A%n%O%n%N",
     "sub_keys": [
       "강원도",
@@ -2471,7 +2513,9 @@
   "KR": {
     "country_name": "SOUTH KOREA",
     "lang": "ko",
-    "languages": "ko",
+    "languages": [
+      "ko"
+    ],
     "fmt": "%S %C%D%n%A%n%O%n%N%n%Z",
     "require": "ACSZ",
     "zip_regex": "\\d{5}",
@@ -2546,7 +2590,9 @@
   "KY": {
     "country_name": "CAYMAN ISLANDS",
     "lang": "en",
-    "languages": "en",
+    "languages": [
+      "en"
+    ],
     "fmt": "%N%n%O%n%A%n%S %Z",
     "require": "AS",
     "zip_regex": "KY\\d-\\d{4}",
@@ -2760,7 +2806,9 @@
   "MX": {
     "country_name": "MEXICO",
     "lang": "es",
-    "languages": "es",
+    "languages": [
+      "es"
+    ],
     "fmt": "%N%n%O%n%A%n%D%n%Z %C, %S",
     "require": "ACSZ",
     "zip_regex": "\\d{5}",
@@ -2874,7 +2922,9 @@
   "MY": {
     "country_name": "MALAYSIA",
     "lang": "ms",
-    "languages": "ms",
+    "languages": [
+      "ms"
+    ],
     "fmt": "%N%n%O%n%A%n%D%n%Z %C%n%S",
     "require": "ACZ",
     "zip_regex": "\\d{5}",
@@ -2922,7 +2972,9 @@
   "MZ": {
     "country_name": "MOZAMBIQUE",
     "lang": "pt",
-    "languages": "pt",
+    "languages": [
+      "pt"
+    ],
     "fmt": "%N%n%O%n%A%n%Z %C%S",
     "zip_regex": "\\d{4}",
     "zip_example": "1102,1119,3212",
@@ -2982,7 +3034,9 @@
   "NG": {
     "country_name": "NIGERIA",
     "lang": "en",
-    "languages": "en",
+    "languages": [
+      "en"
+    ],
     "fmt": "%N%n%O%n%A%n%D%n%C %Z%n%S",
     "zip_regex": "\\d{6}",
     "zip_example": "930283,300001,931104",
@@ -3070,7 +3124,9 @@
   "NI": {
     "country_name": "NICARAGUA",
     "lang": "es",
-    "languages": "es",
+    "languages": [
+      "es"
+    ],
     "fmt": "%N%n%O%n%A%n%Z%n%C, %S",
     "zip_regex": "\\d{5}",
     "zip_example": "52000",
@@ -3142,7 +3198,9 @@
   "NR": {
     "country_name": "NAURU CENTRAL PACIFIC",
     "lang": "en",
-    "languages": "en",
+    "languages": [
+      "en"
+    ],
     "fmt": "%N%n%O%n%A%n%S",
     "require": "AS",
     "state_name_type": "district",
@@ -3203,7 +3261,9 @@
   "PE": {
     "country_name": "PERU",
     "lang": "es",
-    "languages": "es",
+    "languages": [
+      "es"
+    ],
     "fmt": "%N%n%O%n%A%n%C %Z%n%S",
     "zip_regex": "(?:LIMA \\d{1,2}|CALLAO 0?\\d)|[0-2]\\d{4}",
     "zip_example": "LIMA 23,LIMA 42,CALLAO 2,02001",
@@ -3284,7 +3344,9 @@
   "PH": {
     "country_name": "PHILIPPINES",
     "lang": "en",
-    "languages": "en",
+    "languages": [
+      "en"
+    ],
     "fmt": "%N%n%O%n%A%n%D, %C%n%Z %S",
     "zip_regex": "\\d{4}",
     "zip_example": "1008,1050,1135,1207,2000,1000",
@@ -3552,7 +3614,9 @@
   "RU": {
     "country_name": "RUSSIAN FEDERATION",
     "lang": "ru",
-    "languages": "ru",
+    "languages": [
+      "ru"
+    ],
     "fmt": "%N%n%O%n%A%n%C%n%S%n%Z",
     "require": "ACSZ",
     "zip_regex": "\\d{6}",
@@ -3912,7 +3976,9 @@
   "SO": {
     "country_name": "SOMALIA",
     "lang": "so",
-    "languages": "so",
+    "languages": [
+      "so"
+    ],
     "fmt": "%N%n%O%n%A%n%C, %S %Z",
     "require": "ACS",
     "zip_regex": "[A-Z]{2} ?\\d{5}",
@@ -3981,7 +4047,9 @@
   "SR": {
     "country_name": "SURINAME",
     "lang": "nl",
-    "languages": "nl",
+    "languages": [
+      "nl"
+    ],
     "fmt": "%N%n%O%n%A%n%C%n%S",
     "sub_keys": [
       "Brokopondo",
@@ -4017,7 +4085,9 @@
   "SV": {
     "country_name": "EL SALVADOR",
     "lang": "es",
-    "languages": "es",
+    "languages": [
+      "es"
+    ],
     "fmt": "%N%n%O%n%A%n%Z-%C%n%S",
     "require": "ACS",
     "zip_regex": "CP [1-3][1-7][0-2]\\d",
@@ -4110,7 +4180,9 @@
   "TH": {
     "country_name": "THAILAND",
     "lang": "th",
-    "languages": "th",
+    "languages": [
+      "th"
+    ],
     "fmt": "%N%n%O%n%A%n%D %C%n%S %Z",
     "zip_regex": "\\d{5}",
     "zip_example": "10150,10210",
@@ -4304,7 +4376,9 @@
   "TR": {
     "country_name": "TURKEY",
     "lang": "tr",
-    "languages": "tr",
+    "languages": [
+      "tr"
+    ],
     "fmt": "%N%n%O%n%A%n%Z %C/%S",
     "require": "ACZ",
     "zip_regex": "\\d{5}",
@@ -4484,7 +4558,9 @@
   "TV": {
     "country_name": "TUVALU",
     "lang": "tyv",
-    "languages": "tyv",
+    "languages": [
+      "tyv"
+    ],
     "fmt": "%N%n%O%n%A%n%C%n%S",
     "state_name_type": "island",
     "sub_keys": [
@@ -4513,7 +4589,9 @@
   "TW": {
     "country_name": "TAIWAN",
     "lang": "zh-Hant",
-    "languages": "zh-Hant",
+    "languages": [
+      "zh-Hant"
+    ],
     "fmt": "%Z%n%S%C%n%A%n%O%n%N",
     "require": "ACSZ",
     "zip_regex": "\\d{3}(?:\\d{2,3})?",
@@ -4579,7 +4657,9 @@
   "UA": {
     "country_name": "UKRAINE",
     "lang": "uk",
-    "languages": "uk",
+    "languages": [
+      "uk"
+    ],
     "fmt": "%N%n%O%n%A%n%C%n%S%n%Z",
     "require": "ACZ",
     "zip_regex": "\\d{5}",
@@ -4690,7 +4770,9 @@
   "US": {
     "country_name": "UNITED STATES",
     "lang": "en",
-    "languages": "en",
+    "languages": [
+      "en"
+    ],
     "fmt": "%N%n%O%n%A%n%C, %S %Z",
     "require": "ACSZ",
     "zip_regex": "(\\d{5})(?:[ \\-](\\d{4}))?",
@@ -4894,7 +4976,9 @@
   "UY": {
     "country_name": "URUGUAY",
     "lang": "es",
-    "languages": "es",
+    "languages": [
+      "es"
+    ],
     "fmt": "%N%n%O%n%A%n%Z %C %S",
     "zip_regex": "\\d{5}",
     "zip_example": "11600",
@@ -4965,7 +5049,9 @@
   "VE": {
     "country_name": "VENEZUELA",
     "lang": "es",
-    "languages": "es",
+    "languages": [
+      "es"
+    ],
     "fmt": "%N%n%O%n%A%n%C %Z, %S",
     "require": "ACS",
     "zip_regex": "\\d{4}",
@@ -5047,7 +5133,9 @@
   "VN": {
     "country_name": "VIET NAM",
     "lang": "vi",
-    "languages": "vi",
+    "languages": [
+      "vi"
+    ],
     "fmt": "%N%n%O%n%A%n%C%n%S %Z",
     "zip_regex": "\\d{5}\\d?",
     "zip_example": "70010,55999",


### PR DESCRIPTION
## Summary

Fixes the panic in the Go address module caused by mixed `string`/`[]string` JSON types in the `languages` field.

## Root cause

The source data has:
- `"languages": "en"` (string) for single-language countries  
- `"languages": ["en", "fr"]` (array) for multi-language countries (CA, ES, HK, IN)

The Go structs typed `Languages` as `string`, causing:
```
panic: failed to load address data: json: cannot unmarshal array into Go struct field AddressInfo.address_format_information.languages of type string
```

## Fix

- Normalize all `languages` values to `[]string` in all three data files (canonical `data.json`, Go-embedded `data.json`, JS `addressConfig.json`)
- Update proto definition: `string languages` → `repeated string languages`
- Update Go structs in `address.pb.go` and `address.go`: `string` → `[]string`
- Update `GetLanguages()` return type: `string` → `[]string`

## Testing

All Go tests pass locally:
```
ok  github.com/razorpay/i18nify/packages/i18nify-go/modules/address  0.621s
ok  github.com/razorpay/i18nify/i18nify-data/go/address  0.552s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)