### PR TITLE
feat(locale): add locale utility functions (Go + JS)

### DIFF
--- a/packages/i18nify-go/modules/locale/format_list.go
+++ b/packages/i18nify-go/modules/locale/format_list.go
@@ -1,0 +1,110 @@
+package locale
+
+import (
+	"fmt"
+	"strings"
+)
+
+var conjunctions = map[string]string{
+	"en": "and", "fr": "et", "de": "und", "es": "y", "pt": "e",
+	"it": "e", "nl": "en", "ja": "と", "zh": "和", "ko": "및",
+	"hi": "और", "ar": "و", "ru": "и", "pl": "i", "sv": "och",
+	"no": "og", "da": "og", "fi": "ja", "tr": "ve",
+}
+
+var disjunctions = map[string]string{
+	"en": "or", "fr": "ou", "de": "oder", "es": "o", "pt": "ou",
+	"it": "o", "nl": "of", "ja": "か", "zh": "或者", "ko": "또는",
+	"hi": "या", "ar": "أو", "ru": "или", "pl": "lub", "sv": "eller",
+	"no": "eller", "da": "eller", "fi": "tai", "tr": "veya",
+}
+
+// FormatListOptions configures FormatList behaviour.
+type FormatListOptions struct {
+	Locale      string           // BCP 47 locale tag; defaults to "en"
+	Type        string           // "conjunction" (and) or "disjunction" (or); defaults to "conjunction"
+	MaxItems    int              // 0 = no limit; N = show first N items then "M others"
+	OthersLabel func(int) string // label for hidden items; nil = default "N others" / "1 other"
+}
+
+// FormatList joins items into a locale-aware grammatical list.
+// Only English applies an Oxford comma; all other locales omit it.
+//
+// Example:
+//
+//	FormatList([]string{"UPI", "Card", "Wallet"}, FormatListOptions{Locale: "en"})
+//	// → "UPI, Card, and Wallet"
+//
+//	FormatList([]string{"A", "B", "C", "D"}, FormatListOptions{Locale: "en", MaxItems: 2})
+//	// → "A, B, and 2 others"
+func FormatList(items []string, opts FormatListOptions) (string, error) {
+	if len(items) == 0 {
+		return "", nil
+	}
+
+	locale := opts.Locale
+	if locale == "" {
+		locale = "en"
+	}
+	lang := baseLang(locale)
+
+	listType := opts.Type
+	if listType == "" {
+		listType = "conjunction"
+	}
+	if listType != "conjunction" && listType != "disjunction" {
+		return "", fmt.Errorf("type must be \"conjunction\" or \"disjunction\", got %q", listType)
+	}
+
+	display := items
+	if opts.MaxItems > 0 && len(items) > opts.MaxItems {
+		hidden := len(items) - opts.MaxItems
+		label := defaultOthersLabel(hidden)
+		if opts.OthersLabel != nil {
+			label = opts.OthersLabel(hidden)
+		}
+		display = append(append([]string{}, items[:opts.MaxItems]...), label)
+	}
+
+	var wordMap map[string]string
+	if listType == "conjunction" {
+		wordMap = conjunctions
+	} else {
+		wordMap = disjunctions
+	}
+
+	word, ok := wordMap[lang]
+	if !ok {
+		word = wordMap["en"]
+		lang = "en" // apply full English rules (Oxford comma) on fallback
+	}
+
+	n := len(display)
+	switch n {
+	case 1:
+		return display[0], nil
+	case 2:
+		return display[0] + " " + word + " " + display[1], nil
+	default:
+		// Oxford comma for English only
+		prefix := strings.Join(display[:n-1], ", ")
+		if lang == "en" {
+			return prefix + ", " + word + " " + display[n-1], nil
+		}
+		return prefix + " " + word + " " + display[n-1], nil
+	}
+}
+
+func baseLang(locale string) string {
+	if idx := strings.IndexAny(locale, "-_"); idx != -1 {
+		return strings.ToLower(locale[:idx])
+	}
+	return strings.ToLower(locale)
+}
+
+func defaultOthersLabel(n int) string {
+	if n == 1 {
+		return "1 other"
+	}
+	return fmt.Sprintf("%d others", n)
+}

--- a/packages/i18nify-go/modules/locale/format_list_test.go
+++ b/packages/i18nify-go/modules/locale/format_list_test.go
@@ -1,0 +1,113 @@
+package locale
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatList_Basic(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []string
+		opts  FormatListOptions
+		want  string
+	}{
+		{"empty slice", []string{}, FormatListOptions{}, ""},
+		{"single item", []string{"UPI"}, FormatListOptions{}, "UPI"},
+		{"two items", []string{"UPI", "Card"}, FormatListOptions{}, "UPI and Card"},
+		{"three items Oxford comma", []string{"UPI", "Card", "Wallet"}, FormatListOptions{}, "UPI, Card, and Wallet"},
+		{"four items", []string{"A", "B", "C", "D"}, FormatListOptions{}, "A, B, C, and D"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FormatList(tt.items, tt.opts)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFormatList_Locales(t *testing.T) {
+	tests := []struct {
+		locale string
+		items  []string
+		want   string
+	}{
+		{"en", []string{"A", "B", "C"}, "A, B, and C"},
+		{"en-US", []string{"A", "B", "C"}, "A, B, and C"},
+		{"fr", []string{"A", "B", "C"}, "A, B et C"},
+		{"fr-FR", []string{"A", "B", "C"}, "A, B et C"},
+		{"de", []string{"A", "B", "C"}, "A, B und C"},
+		{"es", []string{"A", "B", "C"}, "A, B y C"},
+		{"hi", []string{"A", "B", "C"}, "A, B और C"},
+		{"ja", []string{"A", "B", "C"}, "A, B と C"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.locale, func(t *testing.T) {
+			got, err := FormatList(tt.items, FormatListOptions{Locale: tt.locale})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFormatList_Disjunction(t *testing.T) {
+	got, err := FormatList([]string{"A", "B", "C"}, FormatListOptions{Type: "disjunction"})
+	assert.NoError(t, err)
+	assert.Equal(t, "A, B, or C", got)
+}
+
+func TestFormatList_DisjunctionTwo(t *testing.T) {
+	got, err := FormatList([]string{"A", "B"}, FormatListOptions{Type: "disjunction"})
+	assert.NoError(t, err)
+	assert.Equal(t, "A or B", got)
+}
+
+func TestFormatList_Truncation(t *testing.T) {
+	tests := []struct {
+		name     string
+		items    []string
+		maxItems int
+		want     string
+	}{
+		{"2 hidden", []string{"UPI", "Card", "Wallet", "NetBanking"}, 2, "UPI, Card, and 2 others"},
+		{"1 hidden singular", []string{"A", "B", "C"}, 2, "A, B, and 1 other"},
+		{"maxItems >= len shows all", []string{"A", "B", "C"}, 5, "A, B, and C"},
+		{"maxItems=1 three items", []string{"A", "B", "C", "D"}, 1, "A and 3 others"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FormatList(tt.items, FormatListOptions{MaxItems: tt.maxItems})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFormatList_CustomOthersLabel(t *testing.T) {
+	got, err := FormatList([]string{"A", "B", "C", "D"}, FormatListOptions{
+		MaxItems:    2,
+		OthersLabel: func(n int) string { return "and more" },
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "A, B, and and more", got)
+}
+
+func TestFormatList_TruncationWithLocale(t *testing.T) {
+	got, err := FormatList([]string{"A", "B", "C"}, FormatListOptions{Locale: "fr", MaxItems: 1})
+	assert.NoError(t, err)
+	assert.Equal(t, "A et 2 others", got)
+}
+
+func TestFormatList_UnknownLocaleFallsBackToEnglish(t *testing.T) {
+	got, err := FormatList([]string{"A", "B", "C"}, FormatListOptions{Locale: "xx"})
+	assert.NoError(t, err)
+	assert.Equal(t, "A, B, and C", got)
+}
+
+func TestFormatList_InvalidType_Error(t *testing.T) {
+	_, err := FormatList([]string{"A", "B"}, FormatListOptions{Type: "invalid"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "type must be")
+}

--- a/packages/i18nify-go/modules/locale/resolve_locale.go
+++ b/packages/i18nify-go/modules/locale/resolve_locale.go
@@ -1,0 +1,68 @@
+package locale
+
+import (
+	"os"
+	"strings"
+)
+
+// ResolveLocaleOptions configures the locale resolution priority chain.
+type ResolveLocaleOptions struct {
+	// Locale is an explicit locale preference — the "options" layer.
+	// Corresponds to the options layer in the client-side priority chain.
+	Locale string
+
+	// FallbackLocale is returned when no higher-priority signal resolves.
+	// Defaults to "en" when empty.
+	FallbackLocale string
+}
+
+// ResolveLocale resolves a BCP 47 locale string by walking a priority chain.
+//
+// The server-side chain maps the four client-side layers as follows:
+//
+//	Client-side    → Go equivalent
+//	───────────────────────────────────────────────────────────────
+//	storage        → (not applicable — no localStorage in Go)
+//	options        → ResolveLocaleOptions.Locale
+//	browser        → LC_ALL / LC_MESSAGES / LANG environment variables
+//	fallback       → ResolveLocaleOptions.FallbackLocale (default: "en")
+//
+// POSIX charset suffixes are stripped: "en_US.UTF-8" → "en_US".
+// "C" and "POSIX" locale values are treated as absent.
+// The function always returns a non-empty string — it never errors.
+//
+// Example:
+//
+//	ResolveLocale(ResolveLocaleOptions{Locale: "fr-FR"})
+//	// → "fr-FR"
+//
+//	ResolveLocale(ResolveLocaleOptions{FallbackLocale: "ja"})
+//	// → value of LANG env, or "ja" if LANG is unset
+//
+//	ResolveLocale(ResolveLocaleOptions{})
+//	// → value of LANG env, or "en" if LANG is unset
+func ResolveLocale(opts ResolveLocaleOptions) string {
+	// Priority 1: explicit locale option (corresponds to "options" layer)
+	if trimmed := strings.TrimSpace(opts.Locale); trimmed != "" {
+		return trimmed
+	}
+
+	// Priority 2: OS locale environment variables (corresponds to "browser" layer)
+	for _, envVar := range []string{"LC_ALL", "LC_MESSAGES", "LANG"} {
+		val := strings.TrimSpace(os.Getenv(envVar))
+		if val == "" || val == "C" || val == "POSIX" {
+			continue
+		}
+		// Strip charset suffix: "en_US.UTF-8" → "en_US"
+		if dot := strings.IndexByte(val, '.'); dot != -1 {
+			val = val[:dot]
+		}
+		return val
+	}
+
+	// Priority 3: fallback
+	if fallback := strings.TrimSpace(opts.FallbackLocale); fallback != "" {
+		return fallback
+	}
+	return "en"
+}

--- a/packages/i18nify-go/modules/locale/resolve_locale_test.go
+++ b/packages/i18nify-go/modules/locale/resolve_locale_test.go
@@ -1,0 +1,132 @@
+package locale
+
+import (
+	"os"
+	"testing"
+)
+
+// setEnv sets one or more LANG-related env vars for the duration of a test
+// and restores them in t.Cleanup.
+func setEnv(t *testing.T, key, val string) {
+	t.Helper()
+	prev, existed := os.LookupEnv(key)
+	if err := os.Setenv(key, val); err != nil {
+		t.Fatalf("setenv %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if existed {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	prev, existed := os.LookupEnv(key)
+	_ = os.Unsetenv(key)
+	t.Cleanup(func() {
+		if existed {
+			_ = os.Setenv(key, prev)
+		}
+	})
+}
+
+func TestResolveLocale(t *testing.T) {
+	// Ensure a clean env baseline for every sub-test
+	for _, ev := range []string{"LC_ALL", "LC_MESSAGES", "LANG"} {
+		unsetEnv(t, ev)
+	}
+
+	t.Run("Priority 1 — explicit Locale option", func(t *testing.T) {
+		got := ResolveLocale(ResolveLocaleOptions{Locale: "fr-FR"})
+		if got != "fr-FR" {
+			t.Errorf("got %q, want %q", got, "fr-FR")
+		}
+	})
+
+	t.Run("Locale option trims whitespace", func(t *testing.T) {
+		got := ResolveLocale(ResolveLocaleOptions{Locale: "  de-DE  "})
+		if got != "de-DE" {
+			t.Errorf("got %q, want %q", got, "de-DE")
+		}
+	})
+
+	t.Run("Explicit Locale beats OS env", func(t *testing.T) {
+		setEnv(t, "LANG", "pt_BR.UTF-8")
+		got := ResolveLocale(ResolveLocaleOptions{Locale: "es-ES"})
+		if got != "es-ES" {
+			t.Errorf("got %q, want %q", got, "es-ES")
+		}
+	})
+
+	t.Run("Priority 2 — LANG env variable", func(t *testing.T) {
+		setEnv(t, "LANG", "en_US.UTF-8")
+		got := ResolveLocale(ResolveLocaleOptions{})
+		if got != "en_US" {
+			t.Errorf("got %q, want %q", got, "en_US")
+		}
+	})
+
+	t.Run("Priority 2 — LC_ALL beats LANG", func(t *testing.T) {
+		setEnv(t, "LANG", "en_US.UTF-8")
+		setEnv(t, "LC_ALL", "ja_JP.UTF-8")
+		got := ResolveLocale(ResolveLocaleOptions{})
+		if got != "ja_JP" {
+			t.Errorf("got %q, want %q", got, "ja_JP")
+		}
+	})
+
+	t.Run("Priority 2 — charset suffix stripped", func(t *testing.T) {
+		setEnv(t, "LANG", "zh_CN.UTF-8")
+		got := ResolveLocale(ResolveLocaleOptions{})
+		if got != "zh_CN" {
+			t.Errorf("got %q, want %q", got, "zh_CN")
+		}
+	})
+
+	t.Run("Priority 2 — skips C locale", func(t *testing.T) {
+		setEnv(t, "LANG", "C")
+		got := ResolveLocale(ResolveLocaleOptions{FallbackLocale: "en-US"})
+		if got != "en-US" {
+			t.Errorf("got %q, want %q", got, "en-US")
+		}
+	})
+
+	t.Run("Priority 2 — skips POSIX locale", func(t *testing.T) {
+		setEnv(t, "LANG", "POSIX")
+		got := ResolveLocale(ResolveLocaleOptions{FallbackLocale: "en-GB"})
+		if got != "en-GB" {
+			t.Errorf("got %q, want %q", got, "en-GB")
+		}
+	})
+
+	t.Run("Priority 3 — custom FallbackLocale", func(t *testing.T) {
+		got := ResolveLocale(ResolveLocaleOptions{FallbackLocale: "ja"})
+		if got != "ja" {
+			t.Errorf("got %q, want %q", got, "ja")
+		}
+	})
+
+	t.Run("Priority 3 — defaults to 'en' when FallbackLocale is empty", func(t *testing.T) {
+		got := ResolveLocale(ResolveLocaleOptions{})
+		if got != "en" {
+			t.Errorf("got %q, want %q", got, "en")
+		}
+	})
+
+	t.Run("Priority 3 — defaults to 'en' when FallbackLocale is whitespace", func(t *testing.T) {
+		got := ResolveLocale(ResolveLocaleOptions{FallbackLocale: "   "})
+		if got != "en" {
+			t.Errorf("got %q, want %q", got, "en")
+		}
+	})
+
+	t.Run("Never returns empty string", func(t *testing.T) {
+		got := ResolveLocale(ResolveLocaleOptions{})
+		if got == "" {
+			t.Error("got empty string, want non-empty locale")
+		}
+	})
+}

--- a/packages/i18nify-js/src/modules/locale/__tests__/formatList.test.ts
+++ b/packages/i18nify-js/src/modules/locale/__tests__/formatList.test.ts
@@ -1,0 +1,96 @@
+import formatList from '../formatList';
+
+describe('formatList', () => {
+  // Basic joining
+  it('returns empty string for empty array', () => {
+    expect(formatList([])).toBe('');
+  });
+
+  it('returns single item as-is', () => {
+    expect(formatList(['UPI'])).toBe('UPI');
+  });
+
+  it('joins two items with "and"', () => {
+    expect(formatList(['UPI', 'Card'])).toBe('UPI and Card');
+  });
+
+  it('joins three items with Oxford comma — en', () => {
+    expect(formatList(['UPI', 'Card', 'Wallet'])).toBe('UPI, Card, and Wallet');
+  });
+
+  it('joins four items — en', () => {
+    expect(formatList(['A', 'B', 'C', 'D'])).toBe('A, B, C, and D');
+  });
+
+  // Locale
+  it('uses locale-correct conjunction for French', () => {
+    expect(formatList(['A', 'B', 'C'], { locale: 'fr' })).toBe('A, B et C');
+  });
+
+  it('uses locale-correct conjunction for German', () => {
+    expect(formatList(['A', 'B', 'C'], { locale: 'de' })).toBe('A, B und C');
+  });
+
+  // type: disjunction
+  it('uses "or" for disjunction type — en', () => {
+    expect(formatList(['A', 'B'], { type: 'disjunction' })).toBe('A or B');
+  });
+
+  it('joins three items with disjunction — en', () => {
+    expect(formatList(['A', 'B', 'C'], { type: 'disjunction' })).toBe(
+      'A, B, or C',
+    );
+  });
+
+  // style
+  it('narrow style omits conjunction words — en', () => {
+    expect(formatList(['A', 'B', 'C'], { style: 'narrow' })).toBe('A, B, C');
+  });
+
+  // Truncation
+  it('truncates with default "N others" label', () => {
+    const result = formatList(['UPI', 'Card', 'Wallet', 'NetBanking'], {
+      maxItems: 2,
+    });
+    expect(result).toBe('UPI, Card, and 2 others');
+  });
+
+  it('truncation of 1 hidden item uses singular "other"', () => {
+    const result = formatList(['A', 'B', 'C'], { maxItems: 2 });
+    expect(result).toBe('A, B, and 1 other');
+  });
+
+  it('maxItems >= items.length shows all items without truncation', () => {
+    expect(formatList(['A', 'B', 'C'], { maxItems: 5 })).toBe('A, B, and C');
+  });
+
+  it('maxItems = 1 truncates to first item plus others label', () => {
+    const result = formatList(['A', 'B', 'C', 'D'], { maxItems: 1 });
+    expect(result).toBe('A and 3 others');
+  });
+
+  it('custom othersLabel function is applied', () => {
+    const result = formatList(['A', 'B', 'C', 'D'], {
+      maxItems: 2,
+      othersLabel: (n) => `${n} more`,
+    });
+    expect(result).toBe('A, B, and 2 more');
+  });
+
+  // Truncation with locale
+  it('truncation respects locale conjunction', () => {
+    const result = formatList(['A', 'B', 'C'], { locale: 'fr', maxItems: 1 });
+    expect(result).toBe('A et 2 others');
+  });
+
+  // Error cases
+  it('throws when items is not an array', () => {
+    expect(() => formatList('not an array' as any)).toThrow();
+  });
+
+  it('throws for invalid locale', () => {
+    expect(() =>
+      formatList(['A', 'B'], { locale: 'zzz-ZZZ-invalid-long' }),
+    ).toThrow();
+  });
+});

--- a/packages/i18nify-js/src/modules/locale/__tests__/resolveLocale.test.ts
+++ b/packages/i18nify-js/src/modules/locale/__tests__/resolveLocale.test.ts
@@ -1,0 +1,141 @@
+import resolveLocale from '../resolveLocale';
+
+// Helpers to control localStorage mock
+const storage: Record<string, string> = {};
+const storageMock = {
+  getItem: jest.fn((key: string) => storage[key] ?? null),
+  setItem: jest.fn((key: string, value: string) => {
+    storage[key] = value;
+  }),
+  removeItem: jest.fn((key: string) => {
+    delete storage[key];
+  }),
+  clear: jest.fn(() => {
+    Object.keys(storage).forEach((k) => delete storage[k]);
+  }),
+};
+
+const setNavigator = (language: string, languages: string[] = [language]) => {
+  Object.defineProperty(window, 'navigator', {
+    value: { language, languages },
+    writable: true,
+    configurable: true,
+  });
+};
+
+beforeEach(() => {
+  storageMock.clear();
+  jest.clearAllMocks();
+  Object.defineProperty(window, 'localStorage', {
+    value: storageMock,
+    writable: true,
+    configurable: true,
+  });
+  // Blank out browser locale so tests start in a clean state
+  setNavigator('', []);
+});
+
+describe('resolveLocale', () => {
+  describe('Priority 1 — localStorage', () => {
+    it('returns stored locale when key is present', () => {
+      storageMock.setItem('i18nify-locale', 'fr-FR');
+      expect(resolveLocale()).toBe('fr-FR');
+    });
+
+    it('accepts a custom storageKey', () => {
+      storageMock.setItem('my-locale', 'de-DE');
+      expect(resolveLocale({ storageKey: 'my-locale' })).toBe('de-DE');
+    });
+
+    it('trims whitespace from the stored value', () => {
+      storageMock.setItem('i18nify-locale', '  ja  ');
+      expect(resolveLocale()).toBe('ja');
+    });
+
+    it('falls through when stored value is whitespace-only', () => {
+      storageMock.setItem('i18nify-locale', '   ');
+      expect(resolveLocale({ locale: 'es-ES' })).toBe('es-ES');
+    });
+
+    it('storage beats explicit locale option', () => {
+      storageMock.setItem('i18nify-locale', 'fr-FR');
+      expect(resolveLocale({ locale: 'es-ES' })).toBe('fr-FR');
+    });
+
+    it('storage beats browser locale', () => {
+      storageMock.setItem('i18nify-locale', 'fr-FR');
+      setNavigator('pt-BR', ['pt-BR']);
+      expect(resolveLocale()).toBe('fr-FR');
+    });
+  });
+
+  describe('Priority 2 — explicit locale option', () => {
+    it('returns explicit locale when no storage value', () => {
+      expect(resolveLocale({ locale: 'es-ES' })).toBe('es-ES');
+    });
+
+    it('trims whitespace from the explicit locale', () => {
+      expect(resolveLocale({ locale: '  ko  ' })).toBe('ko');
+    });
+
+    it('explicit locale beats browser locale', () => {
+      setNavigator('pt-BR', ['pt-BR']);
+      expect(resolveLocale({ locale: 'es-ES' })).toBe('es-ES');
+    });
+
+    it('falls through when explicit locale is whitespace-only', () => {
+      setNavigator('pt-BR', ['pt-BR']);
+      expect(resolveLocale({ locale: '   ' })).toBe('pt-BR');
+    });
+  });
+
+  describe('Priority 3 — browser (navigator)', () => {
+    it('returns navigator.language when no storage or options', () => {
+      setNavigator('pt-BR', []);
+      expect(resolveLocale()).toBe('pt-BR');
+    });
+
+    it('prefers navigator.languages[0] over navigator.language', () => {
+      setNavigator('en', ['zh-CN', 'en']);
+      expect(resolveLocale()).toBe('zh-CN');
+    });
+
+    it('falls back to navigator.language when languages[] is empty', () => {
+      setNavigator('en-GB', []);
+      expect(resolveLocale()).toBe('en-GB');
+    });
+
+    it('browser locale beats fallback', () => {
+      setNavigator('ar', ['ar']);
+      expect(resolveLocale({ fallbackLocale: 'en-US' })).toBe('ar');
+    });
+  });
+
+  describe('Priority 4 — fallback', () => {
+    it('returns "en" by default when all signals are absent', () => {
+      expect(resolveLocale()).toBe('en');
+    });
+
+    it('returns custom fallbackLocale', () => {
+      expect(resolveLocale({ fallbackLocale: 'en-US' })).toBe('en-US');
+    });
+
+    it('falls back to "en" when fallbackLocale is an empty string', () => {
+      expect(resolveLocale({ fallbackLocale: '' })).toBe('en');
+    });
+
+    it('falls back to "en" when fallbackLocale is whitespace-only', () => {
+      expect(resolveLocale({ fallbackLocale: '   ' })).toBe('en');
+    });
+  });
+
+  describe('default options', () => {
+    it('works with no arguments (empty options)', () => {
+      expect(typeof resolveLocale()).toBe('string');
+    });
+
+    it('works with an empty options object', () => {
+      expect(typeof resolveLocale({})).toBe('string');
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/locale/formatList.ts
+++ b/packages/i18nify-js/src/modules/locale/formatList.ts
@@ -1,0 +1,64 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+
+type FormatListOptions = {
+  locale?: string;
+  type?: 'conjunction' | 'disjunction';
+  style?: 'long' | 'short' | 'narrow';
+  maxItems?: number;
+  othersLabel?: (count: number) => string;
+};
+
+/**
+ * Joins an array of strings into a locale-aware grammatical list.
+ * Uses Intl.ListFormat (ECMA-402) for locale-correct conjunctions and separators.
+ * Supports truncation: items beyond maxItems are collapsed into an "N others" label.
+ *
+ * @example
+ * formatList(['UPI', 'Card', 'Wallet'])                           // "UPI, Card, and Wallet"
+ * formatList(['UPI', 'Card', 'Wallet', 'NetBanking'], { maxItems: 2 })  // "UPI, Card, and 2 others"
+ * formatList(['A', 'B', 'C'], { locale: 'fr' })                  // "A, B et C"
+ * formatList(['A', 'B'], { type: 'disjunction' })                // "A or B"
+ */
+const formatList = (
+  items: string[],
+  options: FormatListOptions = {},
+): string => {
+  if (!Array.isArray(items))
+    throw new Error(
+      `Parameter 'items' must be an array of strings. Received: ${typeof items}.`,
+    );
+
+  if (items.length === 0) return '';
+
+  const {
+    locale = 'en',
+    type = 'conjunction',
+    style = 'long',
+    maxItems,
+    othersLabel,
+  } = options;
+
+  let displayItems = [...items];
+
+  if (maxItems !== undefined && maxItems > 0 && items.length > maxItems) {
+    const hidden = items.length - maxItems;
+    const label = othersLabel
+      ? othersLabel(hidden)
+      : `${hidden} ${hidden === 1 ? 'other' : 'others'}`;
+    displayItems = [...items.slice(0, maxItems), label];
+  }
+
+  try {
+    // Intl.ListFormat is ECMA-402; cast required as TS target is ES2015
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return new (Intl as any).ListFormat(locale, { type, style }).format(
+      displayItems,
+    );
+  } catch (err) {
+    throw new Error(
+      `An error occurred while formatting the list. The error details are: ${err instanceof Error ? err.message : err}.`,
+    );
+  }
+};
+
+export default withErrorBoundary<typeof formatList>(formatList);

--- a/packages/i18nify-js/src/modules/locale/index.ts
+++ b/packages/i18nify-js/src/modules/locale/index.ts
@@ -1,0 +1,2 @@
+export { default as formatList } from './formatList';
+export { default as resolveLocale } from './resolveLocale';

--- a/packages/i18nify-js/src/modules/locale/resolveLocale.ts
+++ b/packages/i18nify-js/src/modules/locale/resolveLocale.ts
@@ -1,0 +1,63 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+
+type ResolveLocaleOptions = {
+  /** localStorage key to check. Default: 'i18nify-locale' */
+  storageKey?: string;
+  /** Explicit locale preference — the "options" layer. */
+  locale?: string;
+  /** Returned when all higher-priority signals are absent. Default: 'en' */
+  fallbackLocale?: string;
+};
+
+/**
+ * Resolves a BCP 47 locale string by walking a four-level priority chain:
+ *
+ *   1. **storage** — `localStorage.getItem(storageKey)` (client only)
+ *   2. **options** — the explicit `locale` field
+ *   3. **browser** — `navigator.languages[0]` / `navigator.language` (client only)
+ *   4. **fallback** — `fallbackLocale` (default `'en'`)
+ *
+ * Each level is skipped if its value is empty/whitespace or unavailable.
+ * The function is synchronous and never throws — it always returns a string.
+ *
+ * @example
+ * // localStorage has 'i18nify-locale' = 'fr-FR'
+ * resolveLocale()                                  // → 'fr-FR'
+ *
+ * // no storage, explicit locale passed
+ * resolveLocale({ locale: 'de-DE' })               // → 'de-DE'
+ *
+ * // no storage, no explicit locale, browser says 'pt-BR'
+ * resolveLocale()                                  // → 'pt-BR'
+ *
+ * // SSR / no browser APIs, custom fallback
+ * resolveLocale({ fallbackLocale: 'en-US' })       // → 'en-US'
+ */
+const resolveLocale = (options: ResolveLocaleOptions = {}): string => {
+  const {
+    storageKey = 'i18nify-locale',
+    locale,
+    fallbackLocale = 'en',
+  } = options;
+
+  // Priority 1: storage (localStorage, client environments only)
+  if (typeof window !== 'undefined' && window.localStorage) {
+    const stored = window.localStorage.getItem(storageKey);
+    if (stored?.trim()) return stored.trim();
+  }
+
+  // Priority 2: options (explicitly passed locale)
+  if (locale?.trim()) return locale.trim();
+
+  // Priority 3: browser (navigator.languages / navigator.language)
+  if (typeof window !== 'undefined' && window.navigator) {
+    const browserLocale =
+      window.navigator.languages?.[0] || window.navigator.language;
+    if (browserLocale?.trim()) return browserLocale.trim();
+  }
+
+  // Priority 4: fallback
+  return fallbackLocale?.trim() || 'en';
+};
+
+export default withErrorBoundary<typeof resolveLocale>(resolveLocale);


### PR DESCRIPTION
## Summary
- **Go**: formatList, resolveLocale + tests (locale module)
- **JS**: formatList, resolveLocale + tests

## Test plan
- [ ] Go tests: `cd packages/i18nify-go && go test ./modules/locale/...`
- [ ] JS tests: `yarn workspace @razorpay/i18nify-js test --testPathPattern=locale`

🤖 Generated with [Claude Code](https://claude.com/claude-code)