### PR TITLE
feat(i18n): add i18n key flattening/unflattening utilities (Go + JS)

### DIFF
--- a/packages/i18nify-go/modules/i18n/flatten_keys.go
+++ b/packages/i18nify-go/modules/i18n/flatten_keys.go
@@ -1,0 +1,110 @@
+// Package i18n provides utilities for working with i18n message bundle JSON:
+// flattening nested objects to dot-joined keys and unflattening them back.
+package i18n
+
+import (
+	"fmt"
+	"strings"
+)
+
+const defaultDelimiter = "."
+
+// FlattenOptions tunes FlattenKeys behaviour.
+type FlattenOptions struct {
+	// Delimiter separates key segments in the flattened output. Default: ".".
+	Delimiter string
+}
+
+func resolveDelimiter(opts []FlattenOptions) (string, error) {
+	d := defaultDelimiter
+	if len(opts) > 0 && opts[0].Delimiter != "" {
+		d = opts[0].Delimiter
+	}
+	if d == "" {
+		return "", fmt.Errorf("i18n: delimiter must not be empty")
+	}
+	return d, nil
+}
+
+// FlattenKeys converts a nested map[string]any to a flat map with delimiter-joined keys.
+// Arrays ([]interface{}) and non-map values are treated as leaf values and not recursed into.
+//
+// Example:
+//
+//	FlattenKeys(map[string]any{"a": map[string]any{"b": "x"}})
+//	→ map[string]any{"a.b": "x"}
+func FlattenKeys(obj map[string]any, opts ...FlattenOptions) (map[string]any, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("i18n: FlattenKeys: input map must not be nil")
+	}
+	delimiter, err := resolveDelimiter(opts)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]any)
+	flattenRecursive(obj, delimiter, "", result)
+	return result, nil
+}
+
+func flattenRecursive(obj map[string]any, delimiter, prefix string, result map[string]any) {
+	for k, v := range obj {
+		fullKey := k
+		if prefix != "" {
+			fullKey = prefix + delimiter + k
+		}
+		if nested, ok := v.(map[string]any); ok {
+			flattenRecursive(nested, delimiter, fullKey, result)
+		} else {
+			result[fullKey] = v
+		}
+	}
+}
+
+// UnflattenOptions tunes UnflattenKeys behaviour.
+type UnflattenOptions struct {
+	// Delimiter is the separator used in the flat keys. Default: ".".
+	Delimiter string
+}
+
+// UnflattenKeys converts a flat map with delimiter-joined keys to a nested map[string]any.
+// When a key collision occurs (a leaf is later expanded by a deeper key), the deeper key wins.
+//
+// Example:
+//
+//	UnflattenKeys(map[string]any{"a.b": "x"})
+//	→ map[string]any{"a": map[string]any{"b": "x"}}
+func UnflattenKeys(flat map[string]any, opts ...UnflattenOptions) (map[string]any, error) {
+	if flat == nil {
+		return nil, fmt.Errorf("i18n: UnflattenKeys: input map must not be nil")
+	}
+	d := defaultDelimiter
+	if len(opts) > 0 && opts[0].Delimiter != "" {
+		d = opts[0].Delimiter
+	}
+	if d == "" {
+		return nil, fmt.Errorf("i18n: delimiter must not be empty")
+	}
+
+	result := make(map[string]any)
+	for flatKey, val := range flat {
+		parts := strings.Split(flatKey, d)
+		cursor := result
+		for _, part := range parts[:len(parts)-1] {
+			existing, ok := cursor[part]
+			if !ok {
+				nested := make(map[string]any)
+				cursor[part] = nested
+				cursor = nested
+			} else if nested, ok := existing.(map[string]any); ok {
+				cursor = nested
+			} else {
+				// Overwrite non-map leaf — deeper key wins
+				nested := make(map[string]any)
+				cursor[part] = nested
+				cursor = nested
+			}
+		}
+		cursor[parts[len(parts)-1]] = val
+	}
+	return result, nil
+}

--- a/packages/i18nify-go/modules/i18n/flatten_keys_test.go
+++ b/packages/i18nify-go/modules/i18n/flatten_keys_test.go
@@ -1,0 +1,146 @@
+package i18n
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenKeys_Basic(t *testing.T) {
+	input := map[string]any{"a": map[string]any{"b": "x"}}
+	got, err := FlattenKeys(input)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"a.b": "x"}, got)
+}
+
+func TestFlattenKeys_DeepNesting(t *testing.T) {
+	input := map[string]any{"a": map[string]any{"b": map[string]any{"c": "deep"}}}
+	got, err := FlattenKeys(input)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"a.b.c": "deep"}, got)
+}
+
+func TestFlattenKeys_TopLevelLeaves(t *testing.T) {
+	input := map[string]any{"greeting": "hello", "farewell": "bye"}
+	got, err := FlattenKeys(input)
+	require.NoError(t, err)
+	assert.Equal(t, input, got)
+}
+
+func TestFlattenKeys_MessageBundle(t *testing.T) {
+	input := map[string]any{
+		"auth": map[string]any{
+			"login": map[string]any{"title": "Sign in", "submit": "Log in"},
+			"error": "Invalid credentials",
+		},
+		"common": map[string]any{"ok": "OK", "cancel": "Cancel"},
+	}
+	got, err := FlattenKeys(input)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"auth.login.title":  "Sign in",
+		"auth.login.submit": "Log in",
+		"auth.error":        "Invalid credentials",
+		"common.ok":         "OK",
+		"common.cancel":     "Cancel",
+	}, got)
+}
+
+func TestFlattenKeys_ArrayIsLeaf(t *testing.T) {
+	input := map[string]any{"tags": []any{"a", "b"}}
+	got, err := FlattenKeys(input)
+	require.NoError(t, err)
+	assert.Equal(t, input, got)
+}
+
+func TestFlattenKeys_CustomDelimiter(t *testing.T) {
+	input := map[string]any{"a": map[string]any{"b": "x"}}
+	got, err := FlattenKeys(input, FlattenOptions{Delimiter: "/"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"a/b": "x"}, got)
+}
+
+func TestFlattenKeys_EmptyInput(t *testing.T) {
+	got, err := FlattenKeys(map[string]any{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{}, got)
+}
+
+func TestFlattenKeys_NilInput(t *testing.T) {
+	_, err := FlattenKeys(nil)
+	assert.Error(t, err)
+}
+
+func TestUnflattenKeys_Basic(t *testing.T) {
+	input := map[string]any{"a.b": "x"}
+	got, err := UnflattenKeys(input)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"a": map[string]any{"b": "x"}}, got)
+}
+
+func TestUnflattenKeys_DeepNesting(t *testing.T) {
+	input := map[string]any{"a.b.c": "deep"}
+	got, err := UnflattenKeys(input)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"a": map[string]any{"b": map[string]any{"c": "deep"}}}, got)
+}
+
+func TestUnflattenKeys_SiblingKeys(t *testing.T) {
+	input := map[string]any{"a.b": "1", "a.c": "2"}
+	got, err := UnflattenKeys(input)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"a": map[string]any{"b": "1", "c": "2"}}, got)
+}
+
+func TestUnflattenKeys_MessageBundle(t *testing.T) {
+	input := map[string]any{
+		"auth.login.title":  "Sign in",
+		"auth.login.submit": "Log in",
+		"auth.error":        "Invalid credentials",
+		"common.ok":         "OK",
+		"common.cancel":     "Cancel",
+	}
+	got, err := UnflattenKeys(input)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"auth": map[string]any{
+			"login": map[string]any{"title": "Sign in", "submit": "Log in"},
+			"error": "Invalid credentials",
+		},
+		"common": map[string]any{"ok": "OK", "cancel": "Cancel"},
+	}, got)
+}
+
+func TestUnflattenKeys_CustomDelimiter(t *testing.T) {
+	input := map[string]any{"a/b": "x"}
+	got, err := UnflattenKeys(input, UnflattenOptions{Delimiter: "/"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"a": map[string]any{"b": "x"}}, got)
+}
+
+func TestUnflattenKeys_EmptyInput(t *testing.T) {
+	got, err := UnflattenKeys(map[string]any{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{}, got)
+}
+
+func TestUnflattenKeys_NilInput(t *testing.T) {
+	_, err := UnflattenKeys(nil)
+	assert.Error(t, err)
+}
+
+func TestFlattenUnflatten_RoundTrip(t *testing.T) {
+	original := map[string]any{
+		"auth": map[string]any{
+			"login": map[string]any{"title": "Sign in"},
+			"error": "Oops",
+		},
+		"common": map[string]any{"ok": "OK"},
+	}
+	flat, err := FlattenKeys(original)
+	require.NoError(t, err)
+	restored, err := UnflattenKeys(flat)
+	require.NoError(t, err)
+	assert.Equal(t, original, restored)
+}

--- a/packages/i18nify-js/src/modules/i18n/__tests__/flattenKeys.test.ts
+++ b/packages/i18nify-js/src/modules/i18n/__tests__/flattenKeys.test.ts
@@ -1,0 +1,104 @@
+import { flattenKeys } from '../index';
+
+describe('flattenKeys', () => {
+  describe('basic flattening', () => {
+    it('flattens a single nested level', () => {
+      expect(flattenKeys({ a: { b: 'x' } })).toEqual({ 'a.b': 'x' });
+    });
+
+    it('flattens deeply nested objects', () => {
+      expect(flattenKeys({ a: { b: { c: 'deep' } } })).toEqual({
+        'a.b.c': 'deep',
+      });
+    });
+
+    it('preserves top-level leaf keys unchanged', () => {
+      expect(flattenKeys({ greeting: 'hello', farewell: 'bye' })).toEqual({
+        greeting: 'hello',
+        farewell: 'bye',
+      });
+    });
+
+    it('handles mixed depth correctly', () => {
+      expect(flattenKeys({ a: { b: 'nested' }, c: 'top' })).toEqual({
+        'a.b': 'nested',
+        c: 'top',
+      });
+    });
+  });
+
+  describe('i18n message bundle round-trip', () => {
+    it('flattens a realistic message bundle', () => {
+      const input = {
+        auth: {
+          login: { title: 'Sign in', submit: 'Log in' },
+          error: 'Invalid credentials',
+        },
+        common: { ok: 'OK', cancel: 'Cancel' },
+      };
+      expect(flattenKeys(input)).toEqual({
+        'auth.login.title': 'Sign in',
+        'auth.login.submit': 'Log in',
+        'auth.error': 'Invalid credentials',
+        'common.ok': 'OK',
+        'common.cancel': 'Cancel',
+      });
+    });
+  });
+
+  describe('leaf value types', () => {
+    it('preserves null as a leaf', () => {
+      expect(flattenKeys({ a: { b: null } })).toEqual({ 'a.b': null });
+    });
+
+    it('preserves numbers as leaves', () => {
+      expect(flattenKeys({ count: { max: 42 } })).toEqual({
+        'count.max': 42,
+      });
+    });
+
+    it('preserves booleans as leaves', () => {
+      expect(flattenKeys({ feature: { enabled: true } })).toEqual({
+        'feature.enabled': true,
+      });
+    });
+
+    it('treats arrays as leaf values (does not recurse into them)', () => {
+      expect(flattenKeys({ tags: ['a', 'b'] })).toEqual({
+        tags: ['a', 'b'],
+      });
+    });
+  });
+
+  describe('custom delimiter', () => {
+    it('supports "/" as delimiter', () => {
+      expect(flattenKeys({ a: { b: 'x' } }, { delimiter: '/' })).toEqual({
+        'a/b': 'x',
+      });
+    });
+
+    it('supports "__" as delimiter', () => {
+      expect(flattenKeys({ ns: { key: 'val' } }, { delimiter: '__' })).toEqual({
+        ns__key: 'val',
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty object for empty input', () => {
+      expect(flattenKeys({})).toEqual({});
+    });
+
+    it('throws on null input', () => {
+      expect(() =>
+        flattenKeys(null as unknown as Record<string, unknown>),
+      ).toThrow();
+    });
+
+    it('throws on array input', () => {
+      expect(() =>
+        flattenKeys([] as unknown as Record<string, unknown>),
+      ).toThrow();
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/i18n/__tests__/unflattenKeys.test.ts
+++ b/packages/i18nify-js/src/modules/i18n/__tests__/unflattenKeys.test.ts
@@ -1,0 +1,92 @@
+import { unflattenKeys } from '../index';
+
+describe('unflattenKeys', () => {
+  describe('basic unflattening', () => {
+    it('unflattens a single dotted key', () => {
+      expect(unflattenKeys({ 'a.b': 'x' })).toEqual({ a: { b: 'x' } });
+    });
+
+    it('unflattens deeply nested keys', () => {
+      expect(unflattenKeys({ 'a.b.c': 'deep' })).toEqual({
+        a: { b: { c: 'deep' } },
+      });
+    });
+
+    it('preserves top-level keys without dots', () => {
+      expect(unflattenKeys({ greeting: 'hello', farewell: 'bye' })).toEqual({
+        greeting: 'hello',
+        farewell: 'bye',
+      });
+    });
+
+    it('merges sibling keys under the same parent', () => {
+      expect(unflattenKeys({ 'a.b': '1', 'a.c': '2' })).toEqual({
+        a: { b: '1', c: '2' },
+      });
+    });
+  });
+
+  describe('i18n message bundle round-trip', () => {
+    it('unflattens a realistic flat message bundle', () => {
+      const input = {
+        'auth.login.title': 'Sign in',
+        'auth.login.submit': 'Log in',
+        'auth.error': 'Invalid credentials',
+        'common.ok': 'OK',
+        'common.cancel': 'Cancel',
+      };
+      expect(unflattenKeys(input)).toEqual({
+        auth: {
+          login: { title: 'Sign in', submit: 'Log in' },
+          error: 'Invalid credentials',
+        },
+        common: { ok: 'OK', cancel: 'Cancel' },
+      });
+    });
+  });
+
+  describe('round-trip with flattenKeys', () => {
+    it('flattenKeys then unflattenKeys restores the original object', async () => {
+      const { flattenKeys } = await import('../index');
+      const original = {
+        auth: { login: { title: 'Sign in' }, error: 'Oops' },
+        common: { ok: 'OK' },
+      };
+      expect(unflattenKeys(flattenKeys(original))).toEqual(original);
+    });
+  });
+
+  describe('custom delimiter', () => {
+    it('supports "/" as delimiter', () => {
+      expect(unflattenKeys({ 'a/b': 'x' }, { delimiter: '/' })).toEqual({
+        a: { b: 'x' },
+      });
+    });
+  });
+
+  describe('collision handling', () => {
+    it('overwrites a leaf value when a deeper key expands into it', () => {
+      // "a" is set to "leaf", then "a.b" forces "a" to become an object
+      const result = unflattenKeys({ a: 'leaf', 'a.b': 'child' });
+      expect(result).toEqual({ a: { b: 'child' } });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty object for empty input', () => {
+      expect(unflattenKeys({})).toEqual({});
+    });
+
+    it('throws on null input', () => {
+      expect(() =>
+        unflattenKeys(null as unknown as Record<string, unknown>),
+      ).toThrow();
+    });
+
+    it('throws on array input', () => {
+      expect(() =>
+        unflattenKeys([] as unknown as Record<string, unknown>),
+      ).toThrow();
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/i18n/constants.ts
+++ b/packages/i18nify-js/src/modules/i18n/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_DELIMITER = '.';

--- a/packages/i18nify-js/src/modules/i18n/flattenKeys.ts
+++ b/packages/i18nify-js/src/modules/i18n/flattenKeys.ts
@@ -1,0 +1,35 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { DEFAULT_DELIMITER } from './constants';
+import type { FlattenOptions, JsonObject } from './types';
+
+function _flatten(
+  obj: JsonObject,
+  delimiter: string,
+  prefix: string,
+  result: JsonObject,
+): void {
+  for (const key of Object.keys(obj)) {
+    const fullKey = prefix ? `${prefix}${delimiter}${key}` : key;
+    const value = obj[key];
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      _flatten(value as JsonObject, delimiter, fullKey, result);
+    } else {
+      result[fullKey] = value;
+    }
+  }
+}
+
+const flattenKeys = (obj: JsonObject, options?: FlattenOptions): JsonObject => {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    throw new Error('flattenKeys: input must be a plain object.');
+  }
+  const delimiter = options?.delimiter ?? DEFAULT_DELIMITER;
+  if (!delimiter) {
+    throw new Error('flattenKeys: delimiter must be a non-empty string.');
+  }
+  const result: JsonObject = {};
+  _flatten(obj, delimiter, '', result);
+  return result;
+};
+
+export default withErrorBoundary<typeof flattenKeys>(flattenKeys);

--- a/packages/i18nify-js/src/modules/i18n/index.ts
+++ b/packages/i18nify-js/src/modules/i18n/index.ts
@@ -1,0 +1,4 @@
+export { default as flattenKeys } from './flattenKeys';
+export { default as unflattenKeys } from './unflattenKeys';
+export type { FlattenOptions, UnflattenOptions, JsonObject } from './types';
+export { DEFAULT_DELIMITER } from './constants';

--- a/packages/i18nify-js/src/modules/i18n/types.ts
+++ b/packages/i18nify-js/src/modules/i18n/types.ts
@@ -1,0 +1,9 @@
+export type JsonObject = Record<string, unknown>;
+
+export type FlattenOptions = {
+  delimiter?: string;
+};
+
+export type UnflattenOptions = {
+  delimiter?: string;
+};

--- a/packages/i18nify-js/src/modules/i18n/unflattenKeys.ts
+++ b/packages/i18nify-js/src/modules/i18n/unflattenKeys.ts
@@ -1,0 +1,37 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { DEFAULT_DELIMITER } from './constants';
+import type { JsonObject, UnflattenOptions } from './types';
+
+const unflattenKeys = (
+  obj: JsonObject,
+  options?: UnflattenOptions,
+): JsonObject => {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    throw new Error('unflattenKeys: input must be a plain object.');
+  }
+  const delimiter = options?.delimiter ?? DEFAULT_DELIMITER;
+  if (!delimiter) {
+    throw new Error('unflattenKeys: delimiter must be a non-empty string.');
+  }
+  const result: JsonObject = {};
+  for (const flatKey of Object.keys(obj)) {
+    const parts = flatKey.split(delimiter);
+    let cursor: JsonObject = result;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      const existing = cursor[part];
+      if (
+        existing === null ||
+        typeof existing !== 'object' ||
+        Array.isArray(existing)
+      ) {
+        cursor[part] = {};
+      }
+      cursor = cursor[part] as JsonObject;
+    }
+    cursor[parts[parts.length - 1]] = obj[flatKey];
+  }
+  return result;
+};
+
+export default withErrorBoundary<typeof unflattenKeys>(unflattenKeys);


### PR DESCRIPTION
## Summary
- **Go**: flattenKeys + tests
- **JS**: flattenKeys, unflattenKeys + tests

## Test plan
- [ ] Go tests: `cd packages/i18nify-go && go test ./modules/i18n/...`
- [ ] JS tests: `yarn workspace @razorpay/i18nify-js test --testPathPattern=i18n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)