### PR TITLE
feat(masking): add data masking utilities (Go + JS)

### DIFF
--- a/packages/i18nify-go/modules/masking/masking.go
+++ b/packages/i18nify-go/modules/masking/masking.go
@@ -1,0 +1,189 @@
+// Package masking provides display-safe masking utilities for sensitive values
+// such as payment card numbers (PCI DSS §3.4) and phone numbers.
+package masking
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+const (
+	defaultMaskChar   = "X"
+	defaultVisible    = 4
+	defaultGroupSize  = 4
+	defaultGroupSep   = " "
+)
+
+// MaskCardOptions tunes MaskCardNumber behaviour.
+type MaskCardOptions struct {
+	// MaskChar is the replacement character for hidden digits. Default: "X".
+	MaskChar string
+	// VisibleCount is the number of trailing digits to leave visible. Default: 4.
+	VisibleCount int
+	// GroupSize is the number of digits per output group. Default: 4.
+	// Set NoGrouping to true to suppress grouping entirely.
+	GroupSize int
+	// GroupSeparator is placed between groups. Default: " ".
+	GroupSeparator string
+	// NoGrouping disables group separation and returns a flat masked string.
+	NoGrouping bool
+}
+
+// MaskCardNumber replaces all but the last VisibleCount digits of a card number
+// with MaskChar, then re-groups the output into GroupSize-digit chunks.
+//
+// Input may contain digit, space, or hyphen characters; all other characters
+// are rejected.
+//
+// Example:
+//
+//	MaskCardNumber("4111111111111111")     → "XXXX XXXX XXXX 1111"
+//	MaskCardNumber("4111 1111 1111 1111") → "XXXX XXXX XXXX 1111"
+func MaskCardNumber(cardNumber string, opts ...MaskCardOptions) (string, error) {
+	if strings.TrimSpace(cardNumber) == "" {
+		return "", fmt.Errorf("masking: MaskCardNumber: cardNumber must not be empty")
+	}
+
+	maskChar := defaultMaskChar
+	visible := defaultVisible
+	groupSize := defaultGroupSize
+	groupSep := defaultGroupSep
+	noGrouping := false
+
+	if len(opts) > 0 {
+		o := opts[0]
+		if o.MaskChar != "" {
+			maskChar = o.MaskChar
+		}
+		if o.VisibleCount > 0 {
+			visible = o.VisibleCount
+		}
+		if o.GroupSize > 0 {
+			groupSize = o.GroupSize
+		}
+		if o.GroupSeparator != "" {
+			groupSep = o.GroupSeparator
+		}
+		noGrouping = o.NoGrouping
+	}
+
+	var digits strings.Builder
+	for _, ch := range cardNumber {
+		if ch == ' ' || ch == '-' {
+			continue
+		}
+		if !unicode.IsDigit(ch) {
+			return "", fmt.Errorf(
+				"masking: MaskCardNumber: invalid character %q — only digits, spaces, and hyphens allowed",
+				ch,
+			)
+		}
+		digits.WriteRune(ch)
+	}
+	ds := digits.String()
+	if ds == "" {
+		return "", fmt.Errorf("masking: MaskCardNumber: cardNumber contains no digits")
+	}
+
+	maskLen := len(ds) - visible
+	if maskLen < 0 {
+		maskLen = 0
+	}
+
+	var masked strings.Builder
+	for i, ch := range ds {
+		if i < maskLen {
+			masked.WriteString(maskChar)
+		} else {
+			masked.WriteRune(ch)
+		}
+	}
+
+	if noGrouping {
+		return masked.String(), nil
+	}
+
+	m := masked.String()
+	var groups []string
+	for i := 0; i < len(m); i += groupSize {
+		end := i + groupSize
+		if end > len(m) {
+			end = len(m)
+		}
+		groups = append(groups, m[i:end])
+	}
+	return strings.Join(groups, groupSep), nil
+}
+
+// MaskPhoneOptions tunes MaskPhoneNumber behaviour.
+type MaskPhoneOptions struct {
+	// MaskChar is the replacement character for hidden digits. Default: "X".
+	MaskChar string
+	// VisibleCount is the number of trailing digits to leave visible. Default: 4.
+	VisibleCount int
+}
+
+// MaskPhoneNumber replaces all but the last VisibleCount digit characters with
+// MaskChar, preserving non-digit separators (spaces, hyphens, dots, parentheses)
+// and the leading '+' sign in their original positions.
+//
+// Example:
+//
+//	MaskPhoneNumber("+1-800-555-1234") → "+X-XXX-XXX-1234"
+//	MaskPhoneNumber("+919876543210")   → "+XXXXXXXX3210"
+func MaskPhoneNumber(phone string, opts ...MaskPhoneOptions) (string, error) {
+	if strings.TrimSpace(phone) == "" {
+		return "", fmt.Errorf("masking: MaskPhoneNumber: phone must not be empty")
+	}
+
+	maskChar := defaultMaskChar
+	visible := defaultVisible
+
+	if len(opts) > 0 {
+		o := opts[0]
+		if o.MaskChar != "" {
+			maskChar = o.MaskChar
+		}
+		if o.VisibleCount > 0 {
+			visible = o.VisibleCount
+		}
+	}
+
+	trimmed := strings.TrimSpace(phone)
+	prefix := ""
+	rest := trimmed
+	if strings.HasPrefix(trimmed, "+") {
+		prefix = "+"
+		rest = trimmed[1:]
+	}
+
+	digitCount := 0
+	for _, ch := range rest {
+		if unicode.IsDigit(ch) {
+			digitCount++
+		}
+	}
+
+	maskFrom := digitCount - visible
+	if maskFrom < 0 {
+		maskFrom = 0
+	}
+
+	var result strings.Builder
+	result.WriteString(prefix)
+	digitsSeen := 0
+	for _, ch := range rest {
+		if unicode.IsDigit(ch) {
+			if digitsSeen < maskFrom {
+				result.WriteString(maskChar)
+			} else {
+				result.WriteRune(ch)
+			}
+			digitsSeen++
+		} else {
+			result.WriteRune(ch)
+		}
+	}
+	return result.String(), nil
+}

--- a/packages/i18nify-go/modules/masking/masking_test.go
+++ b/packages/i18nify-go/modules/masking/masking_test.go
@@ -1,0 +1,117 @@
+package masking
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── MaskCardNumber ────────────────────────────────────────────────────────────
+
+func TestMaskCardNumber_Default16Digit(t *testing.T) {
+	got, err := MaskCardNumber("4111111111111111")
+	require.NoError(t, err)
+	assert.Equal(t, "XXXX XXXX XXXX 1111", got)
+}
+
+func TestMaskCardNumber_DefaultWithSpaces(t *testing.T) {
+	got, err := MaskCardNumber("4111 1111 1111 1111")
+	require.NoError(t, err)
+	assert.Equal(t, "XXXX XXXX XXXX 1111", got)
+}
+
+func TestMaskCardNumber_DefaultWithHyphens(t *testing.T) {
+	got, err := MaskCardNumber("4111-1111-1111-1111")
+	require.NoError(t, err)
+	assert.Equal(t, "XXXX XXXX XXXX 1111", got)
+}
+
+func TestMaskCardNumber_15Digit(t *testing.T) {
+	got, err := MaskCardNumber("378282246310005")
+	require.NoError(t, err)
+	assert.Equal(t, "XXXX XXXX XXX0 005", got)
+}
+
+func TestMaskCardNumber_CustomMaskChar(t *testing.T) {
+	got, err := MaskCardNumber("4111111111111111", MaskCardOptions{MaskChar: "*"})
+	require.NoError(t, err)
+	assert.Equal(t, "**** **** **** 1111", got)
+}
+
+func TestMaskCardNumber_CustomVisibleCount(t *testing.T) {
+	got, err := MaskCardNumber("4111111111111111", MaskCardOptions{VisibleCount: 6})
+	require.NoError(t, err)
+	assert.Equal(t, "XXXX XXXX XX11 1111", got)
+}
+
+func TestMaskCardNumber_NoGrouping(t *testing.T) {
+	got, err := MaskCardNumber("4111111111111111", MaskCardOptions{NoGrouping: true})
+	require.NoError(t, err)
+	assert.Equal(t, "XXXXXXXXXXXX1111", got)
+}
+
+func TestMaskCardNumber_CustomGroupSeparator(t *testing.T) {
+	got, err := MaskCardNumber("4111111111111111", MaskCardOptions{GroupSeparator: "-"})
+	require.NoError(t, err)
+	assert.Equal(t, "XXXX-XXXX-XXXX-1111", got)
+}
+
+func TestMaskCardNumber_VisibleCountBeyondLength(t *testing.T) {
+	got, err := MaskCardNumber("1234", MaskCardOptions{VisibleCount: 10})
+	require.NoError(t, err)
+	assert.Equal(t, "1234", got)
+}
+
+func TestMaskCardNumber_EmptyInput(t *testing.T) {
+	_, err := MaskCardNumber("")
+	assert.Error(t, err)
+}
+
+func TestMaskCardNumber_InvalidChar(t *testing.T) {
+	_, err := MaskCardNumber("4111A111111B1111")
+	assert.Error(t, err)
+}
+
+// ── MaskPhoneNumber ───────────────────────────────────────────────────────────
+
+func TestMaskPhoneNumber_USWithSeparators(t *testing.T) {
+	got, err := MaskPhoneNumber("+1-800-555-1234")
+	require.NoError(t, err)
+	assert.Equal(t, "+X-XXX-XXX-1234", got)
+}
+
+func TestMaskPhoneNumber_E164India(t *testing.T) {
+	got, err := MaskPhoneNumber("+919876543210")
+	require.NoError(t, err)
+	assert.Equal(t, "+XXXXXXXX3210", got)
+}
+
+func TestMaskPhoneNumber_NoCountryCode(t *testing.T) {
+	got, err := MaskPhoneNumber("9876543210")
+	require.NoError(t, err)
+	assert.Equal(t, "XXXXXX3210", got)
+}
+
+func TestMaskPhoneNumber_SpaceSeparators(t *testing.T) {
+	got, err := MaskPhoneNumber("+44 020 1234 5678")
+	require.NoError(t, err)
+	assert.Equal(t, "+XX XXX XXXX 5678", got)
+}
+
+func TestMaskPhoneNumber_CustomMaskChar(t *testing.T) {
+	got, err := MaskPhoneNumber("+919876543210", MaskPhoneOptions{MaskChar: "*"})
+	require.NoError(t, err)
+	assert.Equal(t, "+********3210", got)
+}
+
+func TestMaskPhoneNumber_CustomVisibleCount(t *testing.T) {
+	got, err := MaskPhoneNumber("+919876543210", MaskPhoneOptions{VisibleCount: 6})
+	require.NoError(t, err)
+	assert.Equal(t, "+XXXXXX543210", got)
+}
+
+func TestMaskPhoneNumber_EmptyInput(t *testing.T) {
+	_, err := MaskPhoneNumber("")
+	assert.Error(t, err)
+}

--- a/packages/i18nify-js/src/modules/masking/__tests__/maskCardNumber.test.ts
+++ b/packages/i18nify-js/src/modules/masking/__tests__/maskCardNumber.test.ts
@@ -1,0 +1,80 @@
+import { maskCardNumber } from '../index';
+
+describe('maskCardNumber', () => {
+  describe('default masking (last 4 visible, 4-char groups)', () => {
+    it('masks a 16-digit card with no separators', () => {
+      expect(maskCardNumber('4111111111111111')).toBe('XXXX XXXX XXXX 1111');
+    });
+
+    it('masks a 16-digit card with spaces', () => {
+      expect(maskCardNumber('4111 1111 1111 1111')).toBe('XXXX XXXX XXXX 1111');
+    });
+
+    it('masks a 16-digit card with hyphens', () => {
+      expect(maskCardNumber('4111-1111-1111-1111')).toBe('XXXX XXXX XXXX 1111');
+    });
+
+    it('masks a 15-digit Amex card', () => {
+      expect(maskCardNumber('378282246310005')).toBe('XXXX XXXX XXX0 005');
+    });
+
+    it('keeps only the last 4 digits visible', () => {
+      const result = maskCardNumber('5500005555555559');
+      expect(result).toBe('XXXX XXXX XXXX 5559');
+      const visible = result.replace(/[\sX]/g, '');
+      expect(visible).toBe('5559');
+    });
+  });
+
+  describe('options', () => {
+    it('respects custom maskChar', () => {
+      expect(maskCardNumber('4111111111111111', { maskChar: '*' })).toBe(
+        '**** **** **** 1111',
+      );
+    });
+
+    it('respects custom visibleCount', () => {
+      expect(maskCardNumber('4111111111111111', { visibleCount: 6 })).toBe(
+        'XXXX XXXX XX11 1111',
+      );
+    });
+
+    it('disables grouping when groupSize is 0', () => {
+      expect(maskCardNumber('4111111111111111', { groupSize: 0 })).toBe(
+        'XXXXXXXXXXXX1111',
+      );
+    });
+
+    it('respects custom groupSize', () => {
+      expect(maskCardNumber('4111111111111111', { groupSize: 6 })).toBe(
+        'XXXXXX XXXXXX 1111',
+      );
+    });
+
+    it('respects custom groupSeparator', () => {
+      expect(maskCardNumber('4111111111111111', { groupSeparator: '-' })).toBe(
+        'XXXX-XXXX-XXXX-1111',
+      );
+    });
+  });
+
+  describe('short card / edge visibleCount', () => {
+    it('shows full number when visibleCount >= length', () => {
+      expect(maskCardNumber('1234', { visibleCount: 4 })).toBe('1234');
+    });
+
+    it('shows full number when visibleCount > length', () => {
+      expect(maskCardNumber('1234', { visibleCount: 10 })).toBe('1234');
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws on empty string', () => {
+      expect(() => maskCardNumber('')).toThrow();
+    });
+
+    it('throws on non-digit characters other than space/hyphen', () => {
+      expect(() => maskCardNumber('4111A111111B1111')).toThrow();
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/masking/__tests__/maskPhoneNumber.test.ts
+++ b/packages/i18nify-js/src/modules/masking/__tests__/maskPhoneNumber.test.ts
@@ -1,0 +1,57 @@
+import { maskPhoneNumber } from '../index';
+
+describe('maskPhoneNumber', () => {
+  describe('default masking (last 4 visible)', () => {
+    it('masks a US number with separators', () => {
+      expect(maskPhoneNumber('+1-800-555-1234')).toBe('+X-XXX-XXX-1234');
+    });
+
+    it('masks an E.164 Indian number', () => {
+      expect(maskPhoneNumber('+919876543210')).toBe('+XXXXXXXX3210');
+    });
+
+    it('masks a plain 10-digit number (no country code)', () => {
+      expect(maskPhoneNumber('9876543210')).toBe('XXXXXX3210');
+    });
+
+    it('preserves non-digit separators (spaces, hyphens, parens)', () => {
+      expect(maskPhoneNumber('+44 (020) 1234-5678')).toBe(
+        '+XX (XXX) XXXX-5678',
+      );
+    });
+  });
+
+  describe('options', () => {
+    it('respects custom maskChar', () => {
+      expect(maskPhoneNumber('+919876543210', { maskChar: '*' })).toBe(
+        '+********3210',
+      );
+    });
+
+    it('respects custom visibleCount = 6', () => {
+      expect(maskPhoneNumber('+919876543210', { visibleCount: 6 })).toBe(
+        '+XXXXXX543210',
+      );
+    });
+
+    it('shows all digits when visibleCount >= total digit count', () => {
+      expect(maskPhoneNumber('12345', { visibleCount: 10 })).toBe('12345');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles number without leading +', () => {
+      expect(maskPhoneNumber('18005551234')).toBe('XXXXXXX1234');
+    });
+
+    it('handles number with dot separators', () => {
+      expect(maskPhoneNumber('+1.800.555.1234')).toBe('+X.XXX.XXX.1234');
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws on empty string', () => {
+      expect(() => maskPhoneNumber('')).toThrow();
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/masking/constants.ts
+++ b/packages/i18nify-js/src/modules/masking/constants.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_MASK_CHAR = 'X';
+export const DEFAULT_VISIBLE_DIGITS = 4;
+export const DEFAULT_CARD_GROUP_SIZE = 4;
+export const DEFAULT_CARD_GROUP_SEPARATOR = ' ';

--- a/packages/i18nify-js/src/modules/masking/index.ts
+++ b/packages/i18nify-js/src/modules/masking/index.ts
@@ -1,0 +1,9 @@
+export { default as maskCardNumber } from './maskCardNumber';
+export { default as maskPhoneNumber } from './maskPhoneNumber';
+export type { MaskCardOptions, MaskPhoneOptions } from './types';
+export {
+  DEFAULT_MASK_CHAR,
+  DEFAULT_VISIBLE_DIGITS,
+  DEFAULT_CARD_GROUP_SIZE,
+  DEFAULT_CARD_GROUP_SEPARATOR,
+} from './constants';

--- a/packages/i18nify-js/src/modules/masking/maskCardNumber.ts
+++ b/packages/i18nify-js/src/modules/masking/maskCardNumber.ts
@@ -1,0 +1,45 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import {
+  DEFAULT_CARD_GROUP_SEPARATOR,
+  DEFAULT_CARD_GROUP_SIZE,
+  DEFAULT_MASK_CHAR,
+  DEFAULT_VISIBLE_DIGITS,
+} from './constants';
+import type { MaskCardOptions } from './types';
+
+const maskCardNumber = (
+  cardNumber: string,
+  options?: MaskCardOptions,
+): string => {
+  if (!cardNumber || typeof cardNumber !== 'string') {
+    throw new Error('maskCardNumber: cardNumber must be a non-empty string.');
+  }
+
+  const maskChar = options?.maskChar ?? DEFAULT_MASK_CHAR;
+  const visibleCount = options?.visibleCount ?? DEFAULT_VISIBLE_DIGITS;
+  // groupSize: 0 explicitly disables grouping; undefined uses the default
+  const groupSize =
+    options?.groupSize != null ? options.groupSize : DEFAULT_CARD_GROUP_SIZE;
+  const groupSeparator =
+    options?.groupSeparator ?? DEFAULT_CARD_GROUP_SEPARATOR;
+
+  const digits = cardNumber.replace(/[\s-]/g, '');
+  if (!/^\d+$/.test(digits)) {
+    throw new Error(
+      'maskCardNumber: cardNumber may only contain digits, spaces, or hyphens.',
+    );
+  }
+
+  const maskLen = Math.max(0, digits.length - visibleCount);
+  const masked = maskChar.repeat(maskLen) + digits.slice(maskLen);
+
+  if (groupSize === 0) return masked;
+
+  const groups: string[] = [];
+  for (let i = 0; i < masked.length; i += groupSize) {
+    groups.push(masked.slice(i, i + groupSize));
+  }
+  return groups.join(groupSeparator);
+};
+
+export default withErrorBoundary<typeof maskCardNumber>(maskCardNumber);

--- a/packages/i18nify-js/src/modules/masking/maskPhoneNumber.ts
+++ b/packages/i18nify-js/src/modules/masking/maskPhoneNumber.ts
@@ -1,0 +1,36 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { DEFAULT_MASK_CHAR, DEFAULT_VISIBLE_DIGITS } from './constants';
+import type { MaskPhoneOptions } from './types';
+
+const maskPhoneNumber = (phone: string, options?: MaskPhoneOptions): string => {
+  if (!phone || typeof phone !== 'string') {
+    throw new Error('maskPhoneNumber: phone must be a non-empty string.');
+  }
+
+  const maskChar = options?.maskChar ?? DEFAULT_MASK_CHAR;
+  const visibleCount = options?.visibleCount ?? DEFAULT_VISIBLE_DIGITS;
+
+  const trimmed = phone.trim();
+  // Preserve leading '+' (international prefix indicator)
+  const hasPlus = trimmed.startsWith('+');
+  const rest = hasPlus ? trimmed.slice(1) : trimmed;
+
+  // Count total digits (excluding '+')
+  const digitCount = (rest.match(/\d/g) ?? []).length;
+  const maskFrom = Math.max(0, digitCount - visibleCount);
+
+  let digitsSeen = 0;
+  const masked = rest
+    .split('')
+    .map((ch) => {
+      if (/\d/.test(ch)) {
+        return digitsSeen++ < maskFrom ? maskChar : ch;
+      }
+      return ch; // preserve separators (spaces, hyphens, dots, parens, etc.)
+    })
+    .join('');
+
+  return (hasPlus ? '+' : '') + masked;
+};
+
+export default withErrorBoundary<typeof maskPhoneNumber>(maskPhoneNumber);

--- a/packages/i18nify-js/src/modules/masking/types.ts
+++ b/packages/i18nify-js/src/modules/masking/types.ts
@@ -1,0 +1,11 @@
+export type MaskCardOptions = {
+  maskChar?: string;
+  visibleCount?: number;
+  groupSize?: number;
+  groupSeparator?: string;
+};
+
+export type MaskPhoneOptions = {
+  maskChar?: string;
+  visibleCount?: number;
+};


### PR DESCRIPTION
## Summary
- **Go**: masking module (card/phone masking + tests)
- **JS**: maskCardNumber, maskPhoneNumber + tests

## Test plan
- [ ] Go tests: `cd packages/i18nify-go && go test ./modules/masking/...`
- [ ] JS tests: `yarn workspace @razorpay/i18nify-js test --testPathPattern=masking`

🤖 Generated with [Claude Code](https://claude.com/claude-code)