### PR TITLE
feat(tax): add country tax definition utility (Go + JS)

### DIFF
--- a/packages/i18nify-go/modules/tax/get_country_tax_definition.go
+++ b/packages/i18nify-go/modules/tax/get_country_tax_definition.go
@@ -1,0 +1,144 @@
+package tax
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CountryTaxDefinition holds the tax system information for a country.
+type CountryTaxDefinition struct {
+	TaxName      string  `json:"tax_name"`
+	FullName     string  `json:"full_name"`
+	StandardRate float64 `json:"standard_rate"`
+	Notes        string  `json:"notes,omitempty"`
+}
+
+// taxDefinitions maps ISO 3166-1 alpha-2 country codes to their tax system.
+// standard_rate is the standard/headline rate as a percentage.
+// 0 means no federal/general indirect tax or rate is non-uniform (see Notes).
+// Source: OECD Consumption Tax Trends 2024; country tax authority publications.
+var taxDefinitions = map[string]CountryTaxDefinition{
+	// GST — Goods and Services Tax
+	"AU": {TaxName: "GST", FullName: "Goods and Services Tax", StandardRate: 10},
+	"IN": {TaxName: "GST", FullName: "Goods and Services Tax", StandardRate: 18, Notes: "Multiple slabs: 0%, 5%, 12%, 18%, 28%"},
+	"NZ": {TaxName: "GST", FullName: "Goods and Services Tax", StandardRate: 15},
+	"SG": {TaxName: "GST", FullName: "Goods and Services Tax", StandardRate: 9},
+	"PK": {TaxName: "GST", FullName: "General Sales Tax", StandardRate: 17},
+	"CA": {TaxName: "GST/HST", FullName: "Goods and Services Tax / Harmonized Sales Tax", StandardRate: 5, Notes: "Federal GST 5%; provincial HST 13–15% in participating provinces"},
+
+	// SST — Sales and Service Tax
+	"MY": {TaxName: "SST", FullName: "Sales and Service Tax", StandardRate: 10, Notes: "Sales Tax 10%; Service Tax 8%"},
+
+	// Sales Tax (US: no federal rate)
+	"US": {TaxName: "Sales Tax", FullName: "Sales Tax", StandardRate: 0, Notes: "No federal rate; varies by state (0–10.25%)"},
+
+	// Consumption Tax
+	"JP": {TaxName: "CT", FullName: "Consumption Tax", StandardRate: 10},
+
+	// VAT — EU members
+	"AT": {TaxName: "MwSt", FullName: "Mehrwertsteuer", StandardRate: 20},
+	"BE": {TaxName: "TVA/BTW", FullName: "Taxe sur la Valeur Ajoutée / Belasting over de Toegevoegde Waarde", StandardRate: 21},
+	"BG": {TaxName: "ДДС", FullName: "Данък върху добавената стойност", StandardRate: 20},
+	"HR": {TaxName: "PDV", FullName: "Porez na dodanu vrijednost", StandardRate: 25},
+	"CY": {TaxName: "ΦΠΑ", FullName: "Φόρος Προστιθέμενης Αξίας", StandardRate: 19},
+	"CZ": {TaxName: "DPH", FullName: "Daň z přidané hodnoty", StandardRate: 21},
+	"DK": {TaxName: "MOMS", FullName: "Merværdiafgift", StandardRate: 25},
+	"EE": {TaxName: "KM", FullName: "Käibemaks", StandardRate: 22},
+	"FI": {TaxName: "ALV", FullName: "Arvonlisävero", StandardRate: 25.5},
+	"FR": {TaxName: "TVA", FullName: "Taxe sur la Valeur Ajoutée", StandardRate: 20},
+	"DE": {TaxName: "MwSt", FullName: "Mehrwertsteuer", StandardRate: 19},
+	"GR": {TaxName: "ΦΠΑ", FullName: "Φόρος Προστιθέμενης Αξίας", StandardRate: 24},
+	"HU": {TaxName: "ÁFA", FullName: "Általános Forgalmi Adó", StandardRate: 27},
+	"IE": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 23},
+	"IT": {TaxName: "IVA", FullName: "Imposta sul Valore Aggiunto", StandardRate: 22},
+	"LV": {TaxName: "PVN", FullName: "Pievienotās vērtības nodoklis", StandardRate: 21},
+	"LT": {TaxName: "PVM", FullName: "Pridėtinės vertės mokestis", StandardRate: 21},
+	"LU": {TaxName: "TVA", FullName: "Taxe sur la Valeur Ajoutée", StandardRate: 17},
+	"MT": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 18},
+	"NL": {TaxName: "BTW", FullName: "Belasting over de Toegevoegde Waarde", StandardRate: 21},
+	"PL": {TaxName: "VAT", FullName: "Podatek od towarów i usług", StandardRate: 23},
+	"PT": {TaxName: "IVA", FullName: "Imposto sobre o Valor Acrescentado", StandardRate: 23},
+	"RO": {TaxName: "TVA", FullName: "Taxa pe Valoarea Adăugată", StandardRate: 19},
+	"SK": {TaxName: "DPH", FullName: "Daň z pridanej hodnoty", StandardRate: 23},
+	"SI": {TaxName: "DDV", FullName: "Davek na dodano vrednost", StandardRate: 22},
+	"ES": {TaxName: "IVA", FullName: "Impuesto sobre el Valor Añadido", StandardRate: 21},
+	"SE": {TaxName: "MOMS", FullName: "Mervärdesskatt", StandardRate: 25},
+
+	// VAT — non-EU Europe
+	"GB": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 20},
+	"NO": {TaxName: "MVA", FullName: "Merverdiavgift", StandardRate: 25},
+	"CH": {TaxName: "MWST", FullName: "Mehrwertsteuer", StandardRate: 8.1},
+	"IS": {TaxName: "VSK", FullName: "Virðisaukaskattur", StandardRate: 24},
+	"TR": {TaxName: "KDV", FullName: "Katma Değer Vergisi", StandardRate: 20},
+	"RU": {TaxName: "НДС", FullName: "Налог на добавленную стоимость", StandardRate: 20},
+	"UA": {TaxName: "ПДВ", FullName: "Податок на додану вартість", StandardRate: 20},
+
+	// VAT — Middle East & Africa
+	"AE": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 5},
+	"SA": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 15},
+	"BH": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 10},
+	"OM": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 5},
+	"EG": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 14},
+	"NG": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 7.5},
+	"ZA": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 15},
+	"KE": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 16},
+	"GH": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 15},
+	"ET": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 15},
+	"TZ": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 18},
+
+	// VAT — Asia Pacific
+	"CN": {TaxName: "VAT", FullName: "Value Added Tax (增值税)", StandardRate: 13, Notes: "Reduced rates 9% and 6% apply to essential goods and services"},
+	"KR": {TaxName: "VAT", FullName: "Value Added Tax (부가가치세)", StandardRate: 10},
+	"TW": {TaxName: "VAT", FullName: "Business Tax (加值型及非加值型營業稅)", StandardRate: 5},
+	"TH": {TaxName: "VAT", FullName: "Value Added Tax (ภาษีมูลค่าเพิ่ม)", StandardRate: 7},
+	"PH": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 12},
+	"ID": {TaxName: "PPN", FullName: "Pajak Pertambahan Nilai", StandardRate: 12},
+	"VN": {TaxName: "VAT", FullName: "Thuế Giá Trị Gia Tăng", StandardRate: 10},
+	"LK": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 18},
+	"BD": {TaxName: "VAT", FullName: "Value Added Tax (মূল্য সংযোজন কর)", StandardRate: 15},
+	"MM": {TaxName: "CT", FullName: "Commercial Tax", StandardRate: 5},
+	"KH": {TaxName: "VAT", FullName: "Value Added Tax", StandardRate: 10},
+
+	// VAT — Americas
+	"BR": {TaxName: "IBS/CBS", FullName: "Imposto sobre Bens e Serviços / Contribuição sobre Bens e Serviços", StandardRate: 26.5, Notes: "Under tax reform (2024–2033); previously ICMS/ISS/PIS/COFINS"},
+	"MX": {TaxName: "IVA", FullName: "Impuesto al Valor Agregado", StandardRate: 16},
+	"AR": {TaxName: "IVA", FullName: "Impuesto al Valor Agregado", StandardRate: 21},
+	"CL": {TaxName: "IVA", FullName: "Impuesto al Valor Agregado", StandardRate: 19},
+	"CO": {TaxName: "IVA", FullName: "Impuesto al Valor Agregado", StandardRate: 19},
+	"PE": {TaxName: "IGV", FullName: "Impuesto General a las Ventas", StandardRate: 18},
+	"EC": {TaxName: "IVA", FullName: "Impuesto al Valor Agregado", StandardRate: 15},
+	"UY": {TaxName: "IVA", FullName: "Impuesto al Valor Agregado", StandardRate: 22},
+
+	// No general indirect tax
+	"HK": {TaxName: "", FullName: "No general indirect tax", StandardRate: 0, Notes: "No VAT or GST"},
+	"KW": {TaxName: "", FullName: "No general indirect tax", StandardRate: 0, Notes: "No VAT or GST"},
+	"QA": {TaxName: "", FullName: "No general indirect tax", StandardRate: 0, Notes: "VAT planned but not yet implemented as of 2025"},
+}
+
+// GetCountryTaxDefinition returns the tax system definition for the given ISO 3166-1 alpha-2 country code.
+//
+// Returns the tax_name (short label), full_name, standard_rate (%), and optional notes.
+// standard_rate == 0 means no federal/general indirect tax or rate is non-uniform (see Notes).
+// Country codes are case-insensitive.
+//
+// Examples:
+//
+//	GetCountryTaxDefinition("IN")  → {GST, Goods and Services Tax, 18, "Multiple slabs: 0%, 5%, 12%, 18%, 28%"}
+//	GetCountryTaxDefinition("MY")  → {SST, Sales and Service Tax, 10, "Sales Tax 10%; Service Tax 8%"}
+//	GetCountryTaxDefinition("US")  → {Sales Tax, Sales Tax, 0, "No federal rate; varies by state..."}
+//	GetCountryTaxDefinition("GB")  → {VAT, Value Added Tax, 20, ""}
+func GetCountryTaxDefinition(countryCode string) (CountryTaxDefinition, error) {
+	if strings.TrimSpace(countryCode) == "" {
+		return CountryTaxDefinition{}, fmt.Errorf("getCountryTaxDefinition: country code must not be empty")
+	}
+
+	code := strings.ToUpper(strings.TrimSpace(countryCode))
+	def, ok := taxDefinitions[code]
+	if !ok {
+		return CountryTaxDefinition{}, fmt.Errorf(
+			"getCountryTaxDefinition: country code %q is not supported",
+			countryCode,
+		)
+	}
+	return def, nil
+}

--- a/packages/i18nify-go/modules/tax/get_country_tax_definition_test.go
+++ b/packages/i18nify-go/modules/tax/get_country_tax_definition_test.go
@@ -1,0 +1,171 @@
+package tax
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetCountryTaxDefinition(t *testing.T) {
+	t.Run("GST countries", func(t *testing.T) {
+		cases := []struct {
+			code         string
+			wantTaxName  string
+			wantFullName string
+			wantRate     float64
+		}{
+			{"IN", "GST", "Goods and Services Tax", 18},
+			{"AU", "GST", "Goods and Services Tax", 10},
+			{"SG", "GST", "Goods and Services Tax", 9},
+			{"NZ", "GST", "Goods and Services Tax", 15},
+			{"CA", "GST/HST", "Goods and Services Tax / Harmonized Sales Tax", 5},
+		}
+		for _, tc := range cases {
+			def, err := GetCountryTaxDefinition(tc.code)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", tc.code, err)
+				continue
+			}
+			if def.TaxName != tc.wantTaxName {
+				t.Errorf("%s: TaxName = %q, want %q", tc.code, def.TaxName, tc.wantTaxName)
+			}
+			if def.FullName != tc.wantFullName {
+				t.Errorf("%s: FullName = %q, want %q", tc.code, def.FullName, tc.wantFullName)
+			}
+			if def.StandardRate != tc.wantRate {
+				t.Errorf("%s: StandardRate = %v, want %v", tc.code, def.StandardRate, tc.wantRate)
+			}
+		}
+	})
+
+	t.Run("SST — Malaysia", func(t *testing.T) {
+		def, err := GetCountryTaxDefinition("MY")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if def.TaxName != "SST" {
+			t.Errorf("TaxName = %q, want SST", def.TaxName)
+		}
+		if def.FullName != "Sales and Service Tax" {
+			t.Errorf("FullName = %q, want Sales and Service Tax", def.FullName)
+		}
+		if def.StandardRate != 10 {
+			t.Errorf("StandardRate = %v, want 10", def.StandardRate)
+		}
+	})
+
+	t.Run("Sales Tax — US, rate 0, has notes", func(t *testing.T) {
+		def, err := GetCountryTaxDefinition("US")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if def.TaxName != "Sales Tax" {
+			t.Errorf("TaxName = %q, want Sales Tax", def.TaxName)
+		}
+		if def.StandardRate != 0 {
+			t.Errorf("StandardRate = %v, want 0", def.StandardRate)
+		}
+		if !strings.Contains(strings.ToLower(def.Notes), "state") {
+			t.Errorf("Notes %q should mention 'state'", def.Notes)
+		}
+	})
+
+	t.Run("VAT countries", func(t *testing.T) {
+		cases := []struct {
+			code     string
+			taxName  string
+			rate     float64
+		}{
+			{"GB", "VAT", 20},
+			{"DE", "MwSt", 19},
+			{"AE", "VAT", 5},
+			{"HU", "ÁFA", 27},
+			{"JP", "CT", 10},
+		}
+		for _, tc := range cases {
+			def, err := GetCountryTaxDefinition(tc.code)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", tc.code, err)
+				continue
+			}
+			if def.TaxName != tc.taxName {
+				t.Errorf("%s: TaxName = %q, want %q", tc.code, def.TaxName, tc.taxName)
+			}
+			if def.StandardRate != tc.rate {
+				t.Errorf("%s: StandardRate = %v, want %v", tc.code, def.StandardRate, tc.rate)
+			}
+		}
+	})
+
+	t.Run("No-tax countries", func(t *testing.T) {
+		for _, code := range []string{"HK", "KW"} {
+			def, err := GetCountryTaxDefinition(code)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", code, err)
+				continue
+			}
+			if def.TaxName != "" {
+				t.Errorf("%s: TaxName = %q, want empty string", code, def.TaxName)
+			}
+			if def.StandardRate != 0 {
+				t.Errorf("%s: StandardRate = %v, want 0", code, def.StandardRate)
+			}
+		}
+	})
+
+	t.Run("Case-insensitive lookup", func(t *testing.T) {
+		lower, err := GetCountryTaxDefinition("in")
+		if err != nil {
+			t.Fatalf("unexpected error for lowercase 'in': %v", err)
+		}
+		if lower.TaxName != "GST" {
+			t.Errorf("lowercase 'in': TaxName = %q, want GST", lower.TaxName)
+		}
+
+		gbLower, err := GetCountryTaxDefinition("gb")
+		if err != nil {
+			t.Fatalf("unexpected error for lowercase 'gb': %v", err)
+		}
+		if gbLower.TaxName != "VAT" {
+			t.Errorf("lowercase 'gb': TaxName = %q, want VAT", gbLower.TaxName)
+		}
+	})
+
+	t.Run("Return shape — all fields present", func(t *testing.T) {
+		def, err := GetCountryTaxDefinition("FR")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if def.TaxName == "" && def.FullName == "" {
+			t.Error("FR: both TaxName and FullName are empty — unexpected")
+		}
+		_ = def.StandardRate
+		_ = def.Notes
+	})
+
+	t.Run("Error — unknown country code", func(t *testing.T) {
+		_, err := GetCountryTaxDefinition("XX")
+		if err == nil {
+			t.Fatal("expected error for 'XX', got nil")
+		}
+		if !strings.Contains(err.Error(), "not supported") {
+			t.Errorf("error %q should contain 'not supported'", err.Error())
+		}
+	})
+
+	t.Run("Error — empty string", func(t *testing.T) {
+		_, err := GetCountryTaxDefinition("")
+		if err == nil {
+			t.Fatal("expected error for empty string, got nil")
+		}
+		if !strings.Contains(strings.ToLower(err.Error()), "empty") {
+			t.Errorf("error %q should mention 'empty'", err.Error())
+		}
+	})
+
+	t.Run("Error — whitespace-only string", func(t *testing.T) {
+		_, err := GetCountryTaxDefinition("   ")
+		if err == nil {
+			t.Fatal("expected error for whitespace-only string, got nil")
+		}
+	})
+}

--- a/packages/i18nify-js/src/modules/tax/__tests__/getCountryTaxDefinition.test.ts
+++ b/packages/i18nify-js/src/modules/tax/__tests__/getCountryTaxDefinition.test.ts
@@ -1,0 +1,117 @@
+import getCountryTaxDefinition from '../getCountryTaxDefinition';
+
+describe('getCountryTaxDefinition', () => {
+  describe('GST countries', () => {
+    it('IN → GST with standard_rate 18', () => {
+      const def = getCountryTaxDefinition('IN');
+      expect(def.tax_name).toBe('GST');
+      expect(def.full_name).toBe('Goods and Services Tax');
+      expect(def.standard_rate).toBe(18);
+    });
+    it('AU → GST 10%', () => {
+      const def = getCountryTaxDefinition('AU');
+      expect(def.tax_name).toBe('GST');
+      expect(def.standard_rate).toBe(10);
+    });
+    it('SG → GST 9%', () => {
+      const def = getCountryTaxDefinition('SG');
+      expect(def.tax_name).toBe('GST');
+      expect(def.standard_rate).toBe(9);
+    });
+    it('NZ → GST 15%', () => {
+      expect(getCountryTaxDefinition('NZ').standard_rate).toBe(15);
+    });
+    it('CA → GST/HST 5% federal', () => {
+      const def = getCountryTaxDefinition('CA');
+      expect(def.tax_name).toBe('GST/HST');
+      expect(def.standard_rate).toBe(5);
+    });
+  });
+
+  describe('SST countries', () => {
+    it('MY → SST 10%', () => {
+      const def = getCountryTaxDefinition('MY');
+      expect(def.tax_name).toBe('SST');
+      expect(def.full_name).toBe('Sales and Service Tax');
+      expect(def.standard_rate).toBe(10);
+    });
+  });
+
+  describe('Sales Tax (no federal rate)', () => {
+    it('US → Sales Tax, rate 0, has notes', () => {
+      const def = getCountryTaxDefinition('US');
+      expect(def.tax_name).toBe('Sales Tax');
+      expect(def.standard_rate).toBe(0);
+      expect(def.notes).toMatch(/state/i);
+    });
+  });
+
+  describe('VAT countries', () => {
+    it('GB → VAT 20%', () => {
+      const def = getCountryTaxDefinition('GB');
+      expect(def.tax_name).toBe('VAT');
+      expect(def.standard_rate).toBe(20);
+    });
+    it('DE → MwSt 19%', () => {
+      const def = getCountryTaxDefinition('DE');
+      expect(def.tax_name).toBe('MwSt');
+      expect(def.standard_rate).toBe(19);
+    });
+    it('AE → VAT 5%', () => {
+      const def = getCountryTaxDefinition('AE');
+      expect(def.tax_name).toBe('VAT');
+      expect(def.standard_rate).toBe(5);
+    });
+    it('HU → ÁFA 27%', () => {
+      const def = getCountryTaxDefinition('HU');
+      expect(def.tax_name).toBe('ÁFA');
+      expect(def.standard_rate).toBe(27);
+    });
+    it('JP → CT (Consumption Tax) 10%', () => {
+      const def = getCountryTaxDefinition('JP');
+      expect(def.tax_name).toBe('CT');
+      expect(def.standard_rate).toBe(10);
+    });
+  });
+
+  describe('no-tax countries', () => {
+    it('HK → empty tax_name, rate 0', () => {
+      const def = getCountryTaxDefinition('HK');
+      expect(def.tax_name).toBe('');
+      expect(def.standard_rate).toBe(0);
+    });
+    it('KW → empty tax_name, rate 0', () => {
+      const def = getCountryTaxDefinition('KW');
+      expect(def.tax_name).toBe('');
+      expect(def.standard_rate).toBe(0);
+    });
+  });
+
+  describe('case-insensitive lookup', () => {
+    it('lowercase "in" resolves to India GST', () => {
+      expect(getCountryTaxDefinition('in').tax_name).toBe('GST');
+    });
+    it('lowercase "gb" resolves to UK VAT', () => {
+      expect(getCountryTaxDefinition('gb').tax_name).toBe('VAT');
+    });
+  });
+
+  describe('return shape', () => {
+    it('always has all four fields', () => {
+      const def = getCountryTaxDefinition('FR');
+      expect(typeof def.tax_name).toBe('string');
+      expect(typeof def.full_name).toBe('string');
+      expect(typeof def.standard_rate).toBe('number');
+      expect(typeof def.notes).toBe('string');
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws for unknown country code', () => {
+      expect(() => getCountryTaxDefinition('XX')).toThrow('not supported');
+    });
+    it('throws for empty string', () => {
+      expect(() => getCountryTaxDefinition('')).toThrow('invalid');
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/tax/getCountryTaxDefinition.ts
+++ b/packages/i18nify-js/src/modules/tax/getCountryTaxDefinition.ts
@@ -1,0 +1,501 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { CountryTaxDefinition } from './types';
+
+// Per-country tax system definitions.
+// Fields: tax_name (short label), full_name, standard_rate (%), notes.
+// standard_rate = 0 means no general indirect tax or rate varies (see notes).
+// Source: OECD Consumption Tax Trends 2024; country tax authority publications.
+const TAX_DEFINITIONS: Readonly<Record<string, CountryTaxDefinition>> = {
+  // GST — Goods and Services Tax
+  AU: {
+    tax_name: 'GST',
+    full_name: 'Goods and Services Tax',
+    standard_rate: 10,
+    notes: '',
+  },
+  IN: {
+    tax_name: 'GST',
+    full_name: 'Goods and Services Tax',
+    standard_rate: 18,
+    notes: 'Multiple slabs: 0%, 5%, 12%, 18%, 28%',
+  },
+  NZ: {
+    tax_name: 'GST',
+    full_name: 'Goods and Services Tax',
+    standard_rate: 15,
+    notes: '',
+  },
+  SG: {
+    tax_name: 'GST',
+    full_name: 'Goods and Services Tax',
+    standard_rate: 9,
+    notes: '',
+  },
+  PK: {
+    tax_name: 'GST',
+    full_name: 'General Sales Tax',
+    standard_rate: 17,
+    notes: '',
+  },
+  CA: {
+    tax_name: 'GST/HST',
+    full_name: 'Goods and Services Tax / Harmonized Sales Tax',
+    standard_rate: 5,
+    notes: 'Federal GST 5%; provincial HST 13–15% in participating provinces',
+  },
+
+  // SST — Sales and Service Tax
+  MY: {
+    tax_name: 'SST',
+    full_name: 'Sales and Service Tax',
+    standard_rate: 10,
+    notes: 'Sales Tax 10%; Service Tax 8%',
+  },
+
+  // Sales Tax (US: no federal rate)
+  US: {
+    tax_name: 'Sales Tax',
+    full_name: 'Sales Tax',
+    standard_rate: 0,
+    notes: 'No federal rate; varies by state (0–10.25%)',
+  },
+
+  // Consumption Tax
+  JP: {
+    tax_name: 'CT',
+    full_name: 'Consumption Tax',
+    standard_rate: 10,
+    notes: '',
+  },
+
+  // VAT — EU members
+  AT: {
+    tax_name: 'MwSt',
+    full_name: 'Mehrwertsteuer',
+    standard_rate: 20,
+    notes: '',
+  },
+  BE: {
+    tax_name: 'TVA/BTW',
+    full_name:
+      'Taxe sur la Valeur Ajoutée / Belasting over de Toegevoegde Waarde',
+    standard_rate: 21,
+    notes: '',
+  },
+  BG: {
+    tax_name: 'ДДС',
+    full_name: 'Данък върху добавената стойност',
+    standard_rate: 20,
+    notes: '',
+  },
+  HR: {
+    tax_name: 'PDV',
+    full_name: 'Porez na dodanu vrijednost',
+    standard_rate: 25,
+    notes: '',
+  },
+  CY: {
+    tax_name: 'ΦΠΑ',
+    full_name: 'Φόρος Προστιθέμενης Αξίας',
+    standard_rate: 19,
+    notes: '',
+  },
+  CZ: {
+    tax_name: 'DPH',
+    full_name: 'Daň z přidané hodnoty',
+    standard_rate: 21,
+    notes: '',
+  },
+  DK: {
+    tax_name: 'MOMS',
+    full_name: 'Merværdiafgift',
+    standard_rate: 25,
+    notes: '',
+  },
+  EE: { tax_name: 'KM', full_name: 'Käibemaks', standard_rate: 22, notes: '' },
+  FI: {
+    tax_name: 'ALV',
+    full_name: 'Arvonlisävero',
+    standard_rate: 25.5,
+    notes: '',
+  },
+  FR: {
+    tax_name: 'TVA',
+    full_name: 'Taxe sur la Valeur Ajoutée',
+    standard_rate: 20,
+    notes: '',
+  },
+  DE: {
+    tax_name: 'MwSt',
+    full_name: 'Mehrwertsteuer',
+    standard_rate: 19,
+    notes: '',
+  },
+  GR: {
+    tax_name: 'ΦΠΑ',
+    full_name: 'Φόρος Προστιθέμενης Αξίας',
+    standard_rate: 24,
+    notes: '',
+  },
+  HU: {
+    tax_name: 'ÁFA',
+    full_name: 'Általános Forgalmi Adó',
+    standard_rate: 27,
+    notes: '',
+  },
+  IE: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 23,
+    notes: '',
+  },
+  IT: {
+    tax_name: 'IVA',
+    full_name: 'Imposta sul Valore Aggiunto',
+    standard_rate: 22,
+    notes: '',
+  },
+  LV: {
+    tax_name: 'PVN',
+    full_name: 'Pievienotās vērtības nodoklis',
+    standard_rate: 21,
+    notes: '',
+  },
+  LT: {
+    tax_name: 'PVM',
+    full_name: 'Pridėtinės vertės mokestis',
+    standard_rate: 21,
+    notes: '',
+  },
+  LU: {
+    tax_name: 'TVA',
+    full_name: 'Taxe sur la Valeur Ajoutée',
+    standard_rate: 17,
+    notes: '',
+  },
+  MT: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 18,
+    notes: '',
+  },
+  NL: {
+    tax_name: 'BTW',
+    full_name: 'Belasting over de Toegevoegde Waarde',
+    standard_rate: 21,
+    notes: '',
+  },
+  PL: {
+    tax_name: 'VAT',
+    full_name: 'Podatek od towarów i usług',
+    standard_rate: 23,
+    notes: '',
+  },
+  PT: {
+    tax_name: 'IVA',
+    full_name: 'Imposto sobre o Valor Acrescentado',
+    standard_rate: 23,
+    notes: '',
+  },
+  RO: {
+    tax_name: 'TVA',
+    full_name: 'Taxa pe Valoarea Adăugată',
+    standard_rate: 19,
+    notes: '',
+  },
+  SK: {
+    tax_name: 'DPH',
+    full_name: 'Daň z pridanej hodnoty',
+    standard_rate: 23,
+    notes: '',
+  },
+  SI: {
+    tax_name: 'DDV',
+    full_name: 'Davek na dodano vrednost',
+    standard_rate: 22,
+    notes: '',
+  },
+  ES: {
+    tax_name: 'IVA',
+    full_name: 'Impuesto sobre el Valor Añadido',
+    standard_rate: 21,
+    notes: '',
+  },
+  SE: {
+    tax_name: 'MOMS',
+    full_name: 'Mervärdesskatt',
+    standard_rate: 25,
+    notes: '',
+  },
+
+  // VAT — non-EU Europe
+  GB: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 20,
+    notes: '',
+  },
+  NO: {
+    tax_name: 'MVA',
+    full_name: 'Merverdiavgift',
+    standard_rate: 25,
+    notes: '',
+  },
+  CH: {
+    tax_name: 'MWST',
+    full_name: 'Mehrwertsteuer',
+    standard_rate: 8.1,
+    notes: '',
+  },
+  IS: {
+    tax_name: 'VSK',
+    full_name: 'Virðisaukaskattur',
+    standard_rate: 24,
+    notes: '',
+  },
+  TR: {
+    tax_name: 'KDV',
+    full_name: 'Katma Değer Vergisi',
+    standard_rate: 20,
+    notes: '',
+  },
+  RU: {
+    tax_name: 'НДС',
+    full_name: 'Налог на добавленную стоимость',
+    standard_rate: 20,
+    notes: '',
+  },
+  UA: {
+    tax_name: 'ПДВ',
+    full_name: 'Податок на додану вартість',
+    standard_rate: 20,
+    notes: '',
+  },
+
+  // VAT — Middle East & Africa
+  AE: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 5,
+    notes: '',
+  },
+  SA: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 15,
+    notes: '',
+  },
+  BH: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 10,
+    notes: '',
+  },
+  EG: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 14,
+    notes: '',
+  },
+  NG: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 7.5,
+    notes: '',
+  },
+  ZA: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 15,
+    notes: '',
+  },
+  KE: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 16,
+    notes: '',
+  },
+  GH: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 15,
+    notes: '',
+  },
+  ET: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 15,
+    notes: '',
+  },
+  TZ: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 18,
+    notes: '',
+  },
+
+  // VAT — Asia Pacific
+  CN: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax (增值税)',
+    standard_rate: 13,
+    notes: 'Reduced rates 9% and 6% apply to essential goods and services',
+  },
+  KR: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax (부가가치세)',
+    standard_rate: 10,
+    notes: '',
+  },
+  TW: {
+    tax_name: 'VAT',
+    full_name: 'Business Tax (加值型及非加值型營業稅)',
+    standard_rate: 5,
+    notes: '',
+  },
+  TH: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax (ภาษีมูลค่าเพิ่ม)',
+    standard_rate: 7,
+    notes: '',
+  },
+  PH: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 12,
+    notes: '',
+  },
+  ID: {
+    tax_name: 'PPN',
+    full_name: 'Pajak Pertambahan Nilai',
+    standard_rate: 12,
+    notes: '',
+  },
+  VN: {
+    tax_name: 'VAT',
+    full_name: 'Thuế Giá Trị Gia Tăng',
+    standard_rate: 10,
+    notes: '',
+  },
+  LK: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 18,
+    notes: '',
+  },
+  BD: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax (মূল্য সংযোজন কর)',
+    standard_rate: 15,
+    notes: '',
+  },
+  MM: {
+    tax_name: 'CT',
+    full_name: 'Commercial Tax',
+    standard_rate: 5,
+    notes: '',
+  },
+  KH: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 10,
+    notes: '',
+  },
+
+  // VAT — Americas
+  BR: {
+    tax_name: 'IBS/CBS',
+    full_name:
+      'Imposto sobre Bens e Serviços / Contribuição sobre Bens e Serviços',
+    standard_rate: 26.5,
+    notes: 'Under tax reform (2024–2033); previously ICMS/ISS/PIS/COFINS',
+  },
+  MX: {
+    tax_name: 'IVA',
+    full_name: 'Impuesto al Valor Agregado',
+    standard_rate: 16,
+    notes: '',
+  },
+  AR: {
+    tax_name: 'IVA',
+    full_name: 'Impuesto al Valor Agregado',
+    standard_rate: 21,
+    notes: '',
+  },
+  CL: {
+    tax_name: 'IVA',
+    full_name: 'Impuesto al Valor Agregado',
+    standard_rate: 19,
+    notes: '',
+  },
+  CO: {
+    tax_name: 'IVA',
+    full_name: 'Impuesto al Valor Agregado',
+    standard_rate: 19,
+    notes: '',
+  },
+  PE: {
+    tax_name: 'IGV',
+    full_name: 'Impuesto General a las Ventas',
+    standard_rate: 18,
+    notes: '',
+  },
+  EC: {
+    tax_name: 'IVA',
+    full_name: 'Impuesto al Valor Agregado',
+    standard_rate: 15,
+    notes: '',
+  },
+  UY: {
+    tax_name: 'IVA',
+    full_name: 'Impuesto al Valor Agregado',
+    standard_rate: 22,
+    notes: '',
+  },
+
+  // No general indirect tax
+  HK: {
+    tax_name: '',
+    full_name: 'No general indirect tax',
+    standard_rate: 0,
+    notes: 'No VAT or GST',
+  },
+  KW: {
+    tax_name: '',
+    full_name: 'No general indirect tax',
+    standard_rate: 0,
+    notes: 'No VAT or GST',
+  },
+  QA: {
+    tax_name: '',
+    full_name: 'No general indirect tax',
+    standard_rate: 0,
+    notes: 'VAT planned but not yet implemented as of 2025',
+  },
+  OM: {
+    tax_name: 'VAT',
+    full_name: 'Value Added Tax',
+    standard_rate: 5,
+    notes: '',
+  },
+};
+
+const getCountryTaxDefinition = (countryCode: string): CountryTaxDefinition => {
+  if (!countryCode)
+    throw new Error(
+      `Parameter 'countryCode' is invalid! The received value was: ${countryCode}.`,
+    );
+
+  const definition = TAX_DEFINITIONS[countryCode.toUpperCase()];
+  if (!definition)
+    throw new Error(
+      `Country code "${countryCode}" is not supported for tax definition lookup. ` +
+        `Supported countries: ${Object.keys(TAX_DEFINITIONS).join(', ')}.`,
+    );
+
+  return definition;
+};
+
+export default withErrorBoundary<typeof getCountryTaxDefinition>(
+  getCountryTaxDefinition,
+);

--- a/packages/i18nify-js/src/modules/tax/index.ts
+++ b/packages/i18nify-js/src/modules/tax/index.ts
@@ -1,0 +1,2 @@
+export { default as getCountryTaxDefinition } from './getCountryTaxDefinition';
+export type { CountryTaxDefinition } from './types';

--- a/packages/i18nify-js/src/modules/tax/types.ts
+++ b/packages/i18nify-js/src/modules/tax/types.ts
@@ -1,0 +1,6 @@
+export interface CountryTaxDefinition {
+  tax_name: string;
+  full_name: string;
+  standard_rate: number;
+  notes: string;
+}


### PR DESCRIPTION
## Summary
- **Go**: tax module with country tax definition + tests
- **JS**: getCountryTaxDefinition + tests

## Test plan
- [ ] Go tests: `cd packages/i18nify-go && go test ./modules/tax/...`
- [ ] JS tests: `yarn workspace @razorpay/i18nify-js test --testPathPattern=tax`

🤖 Generated with [Claude Code](https://claude.com/claude-code)