### PR TITLE
feat(validator): add validation utilities — email, card number (Go + JS)

### DIFF
--- a/packages/i18nify-go/modules/validator/is_valid_card_number.go
+++ b/packages/i18nify-go/modules/validator/is_valid_card_number.go
@@ -1,0 +1,76 @@
+package validator
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var cardSeparatorRegex = regexp.MustCompile(`[\s\-]`)
+var digitsOnlyRegex = regexp.MustCompile(`^\d+$`)
+
+// ISO/IEC 7812-1 primary account number (PAN) length bounds.
+const (
+	CardMinLength = 13
+	CardMaxLength = 19
+)
+
+// CardOptions tunes IsValidCardNumber behaviour.
+type CardOptions struct {
+	// AllowedLengths restricts accepted digit lengths.
+	// Defaults to the ISO/IEC 7812-1 range 13–19 when nil.
+	AllowedLengths []int
+}
+
+// IsValidCardNumber validates a payment card number using the Luhn algorithm
+// (ISO/IEC 7812-1 Annex B). Spaces and hyphens are stripped before validation.
+// Returns an error only when cardNumber is empty.
+func IsValidCardNumber(cardNumber string, opts ...CardOptions) (bool, error) {
+	if strings.TrimSpace(cardNumber) == "" {
+		return false, fmt.Errorf("cardNumber must be a non-empty string")
+	}
+
+	digits := cardSeparatorRegex.ReplaceAllString(cardNumber, "")
+	if !digitsOnlyRegex.MatchString(digits) {
+		return false, nil
+	}
+
+	o := CardOptions{}
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+
+	l := len(digits)
+	if len(o.AllowedLengths) > 0 {
+		found := false
+		for _, al := range o.AllowedLengths {
+			if l == al {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false, nil
+		}
+	} else {
+		if l < CardMinLength || l > CardMaxLength {
+			return false, nil
+		}
+	}
+
+	// Luhn mod-10: double every second digit from the right.
+	sum := 0
+	isEven := false
+	for i := l - 1; i >= 0; i-- {
+		digit := int(digits[i] - '0')
+		if isEven {
+			digit *= 2
+			if digit > 9 {
+				digit -= 9
+			}
+		}
+		sum += digit
+		isEven = !isEven
+	}
+	return sum%10 == 0, nil
+}

--- a/packages/i18nify-go/modules/validator/is_valid_card_number_test.go
+++ b/packages/i18nify-go/modules/validator/is_valid_card_number_test.go
@@ -1,0 +1,60 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidCardNumber_Valid(t *testing.T) {
+	valid := []struct {
+		label string
+		pan   string
+	}{
+		{"Visa test PAN", "4111111111111111"},
+		{"Mastercard test PAN", "5500005555555559"},
+		{"Amex test PAN", "378282246310005"},
+		{"Discover test PAN", "6011111111111117"},
+		{"Visa with spaces", "4111 1111 1111 1111"},
+		{"Visa with hyphens", "4111-1111-1111-1111"},
+	}
+	for _, tc := range valid {
+		ok, err := IsValidCardNumber(tc.pan)
+		assert.NoError(t, err, tc.label)
+		assert.True(t, ok, "expected valid (%s): %q", tc.label, tc.pan)
+	}
+}
+
+func TestIsValidCardNumber_Invalid(t *testing.T) {
+	invalid := []struct {
+		label string
+		pan   string
+	}{
+		{"Luhn check fails", "4111111111111112"},
+		{"too short", "411111111111"},
+		{"too long", "41111111111111110000"},
+		{"contains letters", "4111111111111a11"},
+	}
+	for _, tc := range invalid {
+		ok, err := IsValidCardNumber(tc.pan)
+		assert.NoError(t, err, tc.label)
+		assert.False(t, ok, "expected invalid (%s): %q", tc.label, tc.pan)
+	}
+}
+
+func TestIsValidCardNumber_AllowedLengths(t *testing.T) {
+	// Amex is 15 digits — should fail if only 16-digit cards allowed
+	ok, err := IsValidCardNumber("378282246310005", CardOptions{AllowedLengths: []int{16}})
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	// Allow both 15 and 16
+	ok, err = IsValidCardNumber("378282246310005", CardOptions{AllowedLengths: []int{15, 16}})
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestIsValidCardNumber_EmptyInput(t *testing.T) {
+	_, err := IsValidCardNumber("")
+	assert.Error(t, err)
+}

--- a/packages/i18nify-go/modules/validator/is_valid_email.go
+++ b/packages/i18nify-go/modules/validator/is_valid_email.go
@@ -1,0 +1,48 @@
+// Package validator provides general-purpose input validation utilities:
+// RFC 5322 / W3C HTML5 email address checking and ISO/IEC 7812-1 Luhn card number checking.
+package validator
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// emailRegex is the W3C HTML Living Standard valid e-mail address pattern.
+// Source: https://html.spec.whatwg.org/#valid-e-mail-address
+var emailRegex = regexp.MustCompile(
+	`^[a-zA-Z0-9.!#$%&'*+/=?^_` + "`" + `{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`,
+)
+
+// emailRegexRequireTLD additionally requires at least one dot after "@",
+// rejecting bare hostnames such as "user@localhost".
+var emailRegexRequireTLD = regexp.MustCompile(
+	`^[a-zA-Z0-9.!#$%&'*+/=?^_` + "`" + `{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$`,
+)
+
+// EmailOptions tunes IsValidEmail behaviour.
+type EmailOptions struct {
+	// AllowNoTld permits addresses without a dot-separated TLD (e.g. "user@localhost").
+	// Default: false — a TLD segment is required.
+	AllowNoTld bool
+}
+
+// IsValidEmail reports whether email is a well-formed e-mail address.
+// By default a TLD segment is required; set AllowNoTld to permit bare hostnames.
+// Returns an error only when email is empty.
+func IsValidEmail(email string, opts ...EmailOptions) (bool, error) {
+	if strings.TrimSpace(email) == "" {
+		return false, fmt.Errorf("email must be a non-empty string")
+	}
+
+	o := EmailOptions{}
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+
+	trimmed := strings.TrimSpace(email)
+	if o.AllowNoTld {
+		return emailRegex.MatchString(trimmed), nil
+	}
+	return emailRegexRequireTLD.MatchString(trimmed), nil
+}

--- a/packages/i18nify-go/modules/validator/is_valid_email_test.go
+++ b/packages/i18nify-go/modules/validator/is_valid_email_test.go
@@ -1,0 +1,58 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidEmail_Valid(t *testing.T) {
+	valid := []string{
+		"user@example.com",
+		"user.name+tag@sub.domain.co.uk",
+		"user@domain.io",
+		"first.last@company.org",
+		"user123@host.net",
+	}
+	for _, email := range valid {
+		ok, err := IsValidEmail(email)
+		assert.NoError(t, err, "email: %q", email)
+		assert.True(t, ok, "expected valid: %q", email)
+	}
+}
+
+func TestIsValidEmail_Invalid(t *testing.T) {
+	invalid := []string{
+		"userexample.com",
+		"@example.com",
+		"user@@example.com",
+		"user@",
+		"user@localhost",
+	}
+	for _, email := range invalid {
+		ok, err := IsValidEmail(email)
+		assert.NoError(t, err, "email: %q", email)
+		assert.False(t, ok, "expected invalid: %q", email)
+	}
+}
+
+func TestIsValidEmail_AllowNoTld(t *testing.T) {
+	ok, err := IsValidEmail("user@localhost")
+	assert.NoError(t, err)
+	assert.False(t, ok, "bare hostname should fail by default")
+
+	ok, err = IsValidEmail("user@localhost", EmailOptions{AllowNoTld: true})
+	assert.NoError(t, err)
+	assert.True(t, ok, "bare hostname should pass with AllowNoTld=true")
+}
+
+func TestIsValidEmail_EmptyInput(t *testing.T) {
+	_, err := IsValidEmail("")
+	assert.Error(t, err)
+}
+
+func TestIsValidEmail_TrimsWhitespace(t *testing.T) {
+	ok, err := IsValidEmail("  user@example.com  ")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/packages/i18nify-js/src/modules/validator/__tests__/isValidCardNumber.test.ts
+++ b/packages/i18nify-js/src/modules/validator/__tests__/isValidCardNumber.test.ts
@@ -1,0 +1,57 @@
+import { isValidCardNumber } from '../index';
+
+describe('isValidCardNumber', () => {
+  describe('valid card numbers (Luhn check passes)', () => {
+    it.each([
+      ['Visa test PAN', '4111111111111111'],
+      ['Mastercard test PAN', '5500005555555559'],
+      ['Amex test PAN', '378282246310005'],
+      ['Discover test PAN', '6011111111111117'],
+      ['Visa with spaces', '4111 1111 1111 1111'],
+      ['Visa with hyphens', '4111-1111-1111-1111'],
+    ])('%s: accepts "%s"', (_label, pan) => {
+      expect(isValidCardNumber(pan)).toBe(true);
+    });
+  });
+
+  describe('invalid card numbers', () => {
+    it.each([
+      ['Luhn check fails (last digit off by 1)', '4111111111111112'],
+      ['too short (12 digits)', '411111111111'],
+      ['too long (20 digits)', '41111111111111110000'],
+      ['contains letters', '4111111111111a11'],
+    ])('%s: rejects "%s"', (_label, pan) => {
+      expect(isValidCardNumber(pan)).toBe(false);
+    });
+  });
+
+  describe('allowedLengths option', () => {
+    it('rejects a 15-digit Amex when only 16-digit cards are allowed', () => {
+      expect(
+        isValidCardNumber('378282246310005', { allowedLengths: [16] }),
+      ).toBe(false);
+    });
+
+    it('accepts a 15-digit Amex when 15 is in allowedLengths', () => {
+      expect(
+        isValidCardNumber('378282246310005', { allowedLengths: [15, 16] }),
+      ).toBe(true);
+    });
+  });
+
+  describe('separator handling', () => {
+    it('strips spaces before validating', () => {
+      expect(isValidCardNumber('4111 1111 1111 1111')).toBe(true);
+    });
+
+    it('strips hyphens before validating', () => {
+      expect(isValidCardNumber('4111-1111-1111-1111')).toBe(true);
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws on empty string', () => {
+      expect(() => isValidCardNumber('')).toThrow();
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/validator/__tests__/isValidEmail.test.ts
+++ b/packages/i18nify-js/src/modules/validator/__tests__/isValidEmail.test.ts
@@ -1,0 +1,49 @@
+import { isValidEmail } from '../index';
+
+describe('isValidEmail', () => {
+  describe('valid addresses', () => {
+    it.each([
+      'user@example.com',
+      'user.name+tag@sub.domain.co.uk',
+      'user@domain.io',
+      'first.last@company.org',
+      'user123@host.net',
+      'user@xn--nxasmq6b.com',
+    ])('accepts "%s"', (email) => {
+      expect(isValidEmail(email)).toBe(true);
+    });
+  });
+
+  describe('invalid addresses', () => {
+    it.each([
+      ['missing @', 'userexample.com'],
+      ['empty local part', '@example.com'],
+      ['double @', 'user@@example.com'],
+      ['missing domain', 'user@'],
+      ['space in address', 'us er@example.com'],
+      ['bare localhost (default requires TLD)', 'user@localhost'],
+    ])('%s: rejects "%s"', (_label, email) => {
+      expect(isValidEmail(email)).toBe(false);
+    });
+  });
+
+  describe('allowNoTld option', () => {
+    it('rejects bare hostname by default', () => {
+      expect(isValidEmail('user@localhost')).toBe(false);
+    });
+
+    it('accepts bare hostname when allowNoTld is true', () => {
+      expect(isValidEmail('user@localhost', { allowNoTld: true })).toBe(true);
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws on empty string', () => {
+      expect(() => isValidEmail('')).toThrow();
+    });
+
+    it('trims surrounding whitespace before validation', () => {
+      expect(isValidEmail('  user@example.com  ')).toBe(true);
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/validator/constants.ts
+++ b/packages/i18nify-js/src/modules/validator/constants.ts
@@ -1,0 +1,23 @@
+/**
+ * W3C HTML Living Standard §4.10.1.1 valid e-mail address pattern.
+ * Source: https://html.spec.whatwg.org/#valid-e-mail-address
+ */
+export const EMAIL_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+/**
+ * Looser variant that additionally requires at least one dot after "@",
+ * enforcing a TLD-like segment (rejects bare "user@localhost").
+ */
+export const EMAIL_REGEX_REQUIRE_TLD =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/;
+
+/** Separators stripped from card numbers before digit analysis. */
+export const CARD_SEPARATOR_REGEX = /[\s-]/g;
+
+/**
+ * Minimum and maximum digit lengths defined by ISO/IEC 7812-1 for
+ * primary account numbers (PANs).
+ */
+export const CARD_MIN_LENGTH = 13;
+export const CARD_MAX_LENGTH = 19;

--- a/packages/i18nify-js/src/modules/validator/index.ts
+++ b/packages/i18nify-js/src/modules/validator/index.ts
@@ -1,0 +1,10 @@
+export { default as isValidEmail } from './isValidEmail';
+export { default as isValidCardNumber } from './isValidCardNumber';
+export type { EmailValidationOptions, CardValidationOptions } from './types';
+export {
+  EMAIL_REGEX,
+  EMAIL_REGEX_REQUIRE_TLD,
+  CARD_SEPARATOR_REGEX,
+  CARD_MIN_LENGTH,
+  CARD_MAX_LENGTH,
+} from './constants';

--- a/packages/i18nify-js/src/modules/validator/isValidCardNumber.ts
+++ b/packages/i18nify-js/src/modules/validator/isValidCardNumber.ts
@@ -1,0 +1,47 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import {
+  CARD_MAX_LENGTH,
+  CARD_MIN_LENGTH,
+  CARD_SEPARATOR_REGEX,
+} from './constants';
+import type { CardValidationOptions } from './types';
+
+/**
+ * Validates a payment card number using the Luhn algorithm (ISO/IEC 7812-1 Annex B).
+ * Accepts digits with optional space or hyphen separators (e.g. "4111 1111 1111 1111").
+ */
+const isValidCardNumber = (
+  cardNumber: string,
+  options?: CardValidationOptions,
+): boolean => {
+  if (!cardNumber || typeof cardNumber !== 'string')
+    throw new Error('cardNumber must be a non-empty string.');
+
+  const digits = cardNumber.replace(CARD_SEPARATOR_REGEX, '');
+
+  if (!/^\d+$/.test(digits)) return false;
+
+  const { allowedLengths } = options ?? {};
+  const len = digits.length;
+  if (allowedLengths) {
+    if (!allowedLengths.includes(len)) return false;
+  } else {
+    if (len < CARD_MIN_LENGTH || len > CARD_MAX_LENGTH) return false;
+  }
+
+  // Luhn mod-10 check: double every second digit from the right.
+  let sum = 0;
+  let isEven = false;
+  for (let i = len - 1; i >= 0; i--) {
+    let digit = parseInt(digits[i], 10);
+    if (isEven) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+    sum += digit;
+    isEven = !isEven;
+  }
+  return sum % 10 === 0;
+};
+
+export default withErrorBoundary<typeof isValidCardNumber>(isValidCardNumber);

--- a/packages/i18nify-js/src/modules/validator/isValidEmail.ts
+++ b/packages/i18nify-js/src/modules/validator/isValidEmail.ts
@@ -1,0 +1,16 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { EMAIL_REGEX, EMAIL_REGEX_REQUIRE_TLD } from './constants';
+import type { EmailValidationOptions } from './types';
+
+const isValidEmail = (
+  email: string,
+  options?: EmailValidationOptions,
+): boolean => {
+  if (!email || typeof email !== 'string')
+    throw new Error('email must be a non-empty string.');
+
+  const pattern = options?.allowNoTld ? EMAIL_REGEX : EMAIL_REGEX_REQUIRE_TLD;
+  return pattern.test(email.trim());
+};
+
+export default withErrorBoundary<typeof isValidEmail>(isValidEmail);

--- a/packages/i18nify-js/src/modules/validator/types.ts
+++ b/packages/i18nify-js/src/modules/validator/types.ts
@@ -1,0 +1,12 @@
+export type EmailValidationOptions = {
+  /** When true, allows addresses without a TLD (e.g. "user@localhost"). Default: false. */
+  allowNoTld?: boolean;
+};
+
+export type CardValidationOptions = {
+  /**
+   * Accepted digit lengths. Defaults to the ISO/IEC 7812-1 range 13–19.
+   * Narrow this (e.g. [16]) to accept only specific card types.
+   */
+  allowedLengths?: number[];
+};


### PR DESCRIPTION
## Summary
- **Go**: isValidEmail, isValidCardNumber + tests (validator module)
- **JS**: isValidEmail, isValidCardNumber + tests

## Test plan
- [ ] Go tests: `cd packages/i18nify-go && go test ./modules/validator/...`
- [ ] JS tests: `yarn workspace @razorpay/i18nify-js test --testPathPattern=validator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)