### PR TITLE
feat(mandate): add mandate frequency label utility (Go + JS)

### DIFF
--- a/packages/i18nify-go/modules/mandate/get_mandate_frequency_label.go
+++ b/packages/i18nify-go/modules/mandate/get_mandate_frequency_label.go
@@ -1,0 +1,58 @@
+package mandate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MandateFrequencyLabel holds the display metadata for a recurring payment frequency code.
+// Days is nil for variable-frequency codes (e.g. AS_PRESENTED).
+type MandateFrequencyLabel struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	Days        *int   `json:"days,omitempty"` // approximate days between recurrences; nil for variable
+}
+
+func daysPtr(n int) *int { return &n }
+
+// frequencyLabelMap maps SCREAMING_SNAKE_CASE frequency codes to display metadata.
+// BI_WEEKLY is an alias for FORTNIGHTLY; SEMI_ANNUAL for HALF_YEARLY; ANNUAL for YEARLY.
+var frequencyLabelMap = map[string]MandateFrequencyLabel{
+	"DAILY":        {Label: "Daily", Description: "Recurring every day", Days: daysPtr(1)},
+	"WEEKLY":       {Label: "Weekly", Description: "Recurring every week", Days: daysPtr(7)},
+	"FORTNIGHTLY":  {Label: "Fortnightly", Description: "Recurring every two weeks", Days: daysPtr(14)},
+	"BI_WEEKLY":    {Label: "Bi-Weekly", Description: "Recurring every two weeks", Days: daysPtr(14)},
+	"MONTHLY":      {Label: "Monthly", Description: "Recurring every month", Days: daysPtr(30)},
+	"BI_MONTHLY":   {Label: "Bi-Monthly", Description: "Recurring every two months", Days: daysPtr(60)},
+	"QUARTERLY":    {Label: "Quarterly", Description: "Recurring every three months", Days: daysPtr(90)},
+	"HALF_YEARLY":  {Label: "Half-Yearly", Description: "Recurring every six months", Days: daysPtr(180)},
+	"SEMI_ANNUAL":  {Label: "Semi-Annual", Description: "Recurring every six months", Days: daysPtr(180)},
+	"YEARLY":       {Label: "Yearly", Description: "Recurring every year", Days: daysPtr(365)},
+	"ANNUAL":       {Label: "Annual", Description: "Recurring every year", Days: daysPtr(365)},
+	"AS_PRESENTED": {Label: "As Presented", Description: "Collected as and when presented by the merchant"},
+}
+
+// GetMandateFrequencyLabel returns the display label for the given mandate frequency code.
+//
+// Lookup is case-insensitive. Returns an error for empty or unsupported codes.
+//
+// Examples:
+//
+//	GetMandateFrequencyLabel("DAILY")        → {Daily, Recurring every day, 1}
+//	GetMandateFrequencyLabel("BI_MONTHLY")   → {Bi-Monthly, Recurring every two months, 60}
+//	GetMandateFrequencyLabel("AS_PRESENTED") → {As Presented, Collected as and when..., nil}
+func GetMandateFrequencyLabel(frequencyCode string) (MandateFrequencyLabel, error) {
+	if strings.TrimSpace(frequencyCode) == "" {
+		return MandateFrequencyLabel{}, fmt.Errorf("getMandateFrequencyLabel: frequency code must not be empty")
+	}
+
+	key := strings.ToUpper(strings.TrimSpace(frequencyCode))
+	label, ok := frequencyLabelMap[key]
+	if !ok {
+		return MandateFrequencyLabel{}, fmt.Errorf(
+			"getMandateFrequencyLabel: frequency code %q is not supported",
+			frequencyCode,
+		)
+	}
+	return label, nil
+}

--- a/packages/i18nify-go/modules/mandate/get_mandate_frequency_label_test.go
+++ b/packages/i18nify-go/modules/mandate/get_mandate_frequency_label_test.go
@@ -1,0 +1,138 @@
+package mandate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetMandateFrequencyLabel(t *testing.T) {
+	t.Run("Primary frequency codes", func(t *testing.T) {
+		cases := []struct {
+			code  string
+			label string
+			days  int
+		}{
+			{"DAILY", "Daily", 1},
+			{"WEEKLY", "Weekly", 7},
+			{"FORTNIGHTLY", "Fortnightly", 14},
+			{"MONTHLY", "Monthly", 30},
+			{"BI_MONTHLY", "Bi-Monthly", 60},
+			{"QUARTERLY", "Quarterly", 90},
+			{"HALF_YEARLY", "Half-Yearly", 180},
+			{"YEARLY", "Yearly", 365},
+		}
+		for _, tc := range cases {
+			result, err := GetMandateFrequencyLabel(tc.code)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", tc.code, err)
+				continue
+			}
+			if result.Label != tc.label {
+				t.Errorf("%s: Label = %q, want %q", tc.code, result.Label, tc.label)
+			}
+			if result.Days == nil {
+				t.Errorf("%s: Days is nil, want %d", tc.code, tc.days)
+			} else if *result.Days != tc.days {
+				t.Errorf("%s: Days = %d, want %d", tc.code, *result.Days, tc.days)
+			}
+		}
+	})
+
+	t.Run("Alias codes", func(t *testing.T) {
+		aliases := []struct {
+			code  string
+			label string
+			days  int
+		}{
+			{"BI_WEEKLY", "Bi-Weekly", 14},
+			{"SEMI_ANNUAL", "Semi-Annual", 180},
+			{"ANNUAL", "Annual", 365},
+		}
+		for _, tc := range aliases {
+			result, err := GetMandateFrequencyLabel(tc.code)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", tc.code, err)
+				continue
+			}
+			if result.Label != tc.label {
+				t.Errorf("%s: Label = %q, want %q", tc.code, result.Label, tc.label)
+			}
+			if result.Days == nil || *result.Days != tc.days {
+				t.Errorf("%s: Days = %v, want %d", tc.code, result.Days, tc.days)
+			}
+		}
+	})
+
+	t.Run("AS_PRESENTED — variable frequency, nil days", func(t *testing.T) {
+		result, err := GetMandateFrequencyLabel("AS_PRESENTED")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Label != "As Presented" {
+			t.Errorf("Label = %q, want As Presented", result.Label)
+		}
+		if result.Days != nil {
+			t.Errorf("Days = %d, want nil (variable frequency)", *result.Days)
+		}
+	})
+
+	t.Run("Case-insensitive lookup", func(t *testing.T) {
+		lower, err := GetMandateFrequencyLabel("daily")
+		if err != nil {
+			t.Fatalf("unexpected error for lowercase 'daily': %v", err)
+		}
+		if lower.Label != "Daily" {
+			t.Errorf("Label = %q, want Daily", lower.Label)
+		}
+
+		mixed, err := GetMandateFrequencyLabel("bi_monthly")
+		if err != nil {
+			t.Fatalf("unexpected error for 'bi_monthly': %v", err)
+		}
+		if mixed.Label != "Bi-Monthly" {
+			t.Errorf("Label = %q, want Bi-Monthly", mixed.Label)
+		}
+	})
+
+	t.Run("Description is non-empty for all entries", func(t *testing.T) {
+		codes := []string{"DAILY", "WEEKLY", "FORTNIGHTLY", "BI_WEEKLY", "MONTHLY",
+			"BI_MONTHLY", "QUARTERLY", "HALF_YEARLY", "SEMI_ANNUAL", "YEARLY", "ANNUAL", "AS_PRESENTED"}
+		for _, code := range codes {
+			result, err := GetMandateFrequencyLabel(code)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", code, err)
+				continue
+			}
+			if result.Description == "" {
+				t.Errorf("%s: Description is empty", code)
+			}
+		}
+	})
+
+	t.Run("Error — unknown frequency code", func(t *testing.T) {
+		_, err := GetMandateFrequencyLabel("DECADELY")
+		if err == nil {
+			t.Fatal("expected error for 'DECADELY', got nil")
+		}
+		if !strings.Contains(err.Error(), "not supported") {
+			t.Errorf("error %q should contain 'not supported'", err.Error())
+		}
+	})
+
+	t.Run("Error — empty string", func(t *testing.T) {
+		_, err := GetMandateFrequencyLabel("")
+		if err == nil {
+			t.Fatal("expected error for empty string, got nil")
+		}
+		if !strings.Contains(strings.ToLower(err.Error()), "empty") {
+			t.Errorf("error %q should mention 'empty'", err.Error())
+		}
+	})
+
+	t.Run("Error — whitespace-only", func(t *testing.T) {
+		_, err := GetMandateFrequencyLabel("   ")
+		if err == nil {
+			t.Fatal("expected error for whitespace-only string, got nil")
+		}
+	})
+}

--- a/packages/i18nify-js/src/modules/mandate/__tests__/getMandateFrequencyLabel.test.ts
+++ b/packages/i18nify-js/src/modules/mandate/__tests__/getMandateFrequencyLabel.test.ts
@@ -1,0 +1,139 @@
+import getMandateFrequencyLabel from '../getMandateFrequencyLabel';
+
+describe('getMandateFrequencyLabel', () => {
+  describe('primary frequency codes', () => {
+    it('DAILY → "Daily", days: 1', () => {
+      const result = getMandateFrequencyLabel('DAILY');
+      expect(result.label).toBe('Daily');
+      expect(result.days).toBe(1);
+    });
+
+    it('WEEKLY → "Weekly", days: 7', () => {
+      const result = getMandateFrequencyLabel('WEEKLY');
+      expect(result.label).toBe('Weekly');
+      expect(result.days).toBe(7);
+    });
+
+    it('FORTNIGHTLY → "Fortnightly", days: 14', () => {
+      const result = getMandateFrequencyLabel('FORTNIGHTLY');
+      expect(result.label).toBe('Fortnightly');
+      expect(result.days).toBe(14);
+    });
+
+    it('MONTHLY → "Monthly", days: 30', () => {
+      const result = getMandateFrequencyLabel('MONTHLY');
+      expect(result.label).toBe('Monthly');
+      expect(result.days).toBe(30);
+    });
+
+    it('BI_MONTHLY → "Bi-Monthly", days: 60', () => {
+      const result = getMandateFrequencyLabel('BI_MONTHLY');
+      expect(result.label).toBe('Bi-Monthly');
+      expect(result.days).toBe(60);
+    });
+
+    it('QUARTERLY → "Quarterly", days: 90', () => {
+      const result = getMandateFrequencyLabel('QUARTERLY');
+      expect(result.label).toBe('Quarterly');
+      expect(result.days).toBe(90);
+    });
+
+    it('HALF_YEARLY → "Half-Yearly", days: 180', () => {
+      const result = getMandateFrequencyLabel('HALF_YEARLY');
+      expect(result.label).toBe('Half-Yearly');
+      expect(result.days).toBe(180);
+    });
+
+    it('YEARLY → "Yearly", days: 365', () => {
+      const result = getMandateFrequencyLabel('YEARLY');
+      expect(result.label).toBe('Yearly');
+      expect(result.days).toBe(365);
+    });
+  });
+
+  describe('alias codes', () => {
+    it('BI_WEEKLY → "Bi-Weekly", days: 14', () => {
+      const result = getMandateFrequencyLabel('BI_WEEKLY');
+      expect(result.label).toBe('Bi-Weekly');
+      expect(result.days).toBe(14);
+    });
+
+    it('SEMI_ANNUAL → "Semi-Annual", days: 180', () => {
+      const result = getMandateFrequencyLabel('SEMI_ANNUAL');
+      expect(result.label).toBe('Semi-Annual');
+      expect(result.days).toBe(180);
+    });
+
+    it('ANNUAL → "Annual", days: 365', () => {
+      const result = getMandateFrequencyLabel('ANNUAL');
+      expect(result.label).toBe('Annual');
+      expect(result.days).toBe(365);
+    });
+  });
+
+  describe('AS_PRESENTED — variable frequency', () => {
+    it('label is "As Presented"', () => {
+      const result = getMandateFrequencyLabel('AS_PRESENTED');
+      expect(result.label).toBe('As Presented');
+    });
+
+    it('days is undefined (variable frequency)', () => {
+      const result = getMandateFrequencyLabel('AS_PRESENTED');
+      expect(result.days).toBeUndefined();
+    });
+  });
+
+  describe('case-insensitive lookup', () => {
+    it('lowercase "daily" resolves correctly', () => {
+      expect(getMandateFrequencyLabel('daily').label).toBe('Daily');
+    });
+
+    it('lowercase "bi_monthly" resolves correctly', () => {
+      expect(getMandateFrequencyLabel('bi_monthly').label).toBe('Bi-Monthly');
+    });
+
+    it('mixed case "Monthly" resolves correctly', () => {
+      expect(getMandateFrequencyLabel('Monthly').label).toBe('Monthly');
+    });
+  });
+
+  describe('return shape', () => {
+    it('always has label and description fields', () => {
+      const result = getMandateFrequencyLabel('QUARTERLY');
+      expect(typeof result.label).toBe('string');
+      expect(typeof result.description).toBe('string');
+      expect(result.label.length).toBeGreaterThan(0);
+      expect(result.description.length).toBeGreaterThan(0);
+    });
+
+    it('days is a positive integer when defined', () => {
+      const codes = [
+        'DAILY',
+        'WEEKLY',
+        'FORTNIGHTLY',
+        'MONTHLY',
+        'BI_MONTHLY',
+        'QUARTERLY',
+        'HALF_YEARLY',
+        'YEARLY',
+      ];
+      for (const code of codes) {
+        const result = getMandateFrequencyLabel(code);
+        expect(typeof result.days).toBe('number');
+        expect(result.days).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws for unknown frequency code', () => {
+      expect(() => getMandateFrequencyLabel('DECADELY')).toThrow(
+        'not supported',
+      );
+    });
+
+    it('throws for empty string', () => {
+      expect(() => getMandateFrequencyLabel('')).toThrow('invalid');
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/mandate/getMandateFrequencyLabel.ts
+++ b/packages/i18nify-js/src/modules/mandate/getMandateFrequencyLabel.ts
@@ -1,0 +1,91 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { MandateFrequencyCode, MandateFrequencyLabel } from './types';
+
+// Display labels for recurring mandate frequency codes.
+// `days` is the approximate number of days between recurrences (undefined for AS_PRESENTED).
+// Lookup is case-insensitive. BI_WEEKLY is an alias for FORTNIGHTLY;
+// SEMI_ANNUAL for HALF_YEARLY; ANNUAL for YEARLY.
+const FREQUENCY_LABEL_MAP: Readonly<Record<string, MandateFrequencyLabel>> = {
+  DAILY: {
+    label: 'Daily',
+    description: 'Recurring every day',
+    days: 1,
+  },
+  WEEKLY: {
+    label: 'Weekly',
+    description: 'Recurring every week',
+    days: 7,
+  },
+  FORTNIGHTLY: {
+    label: 'Fortnightly',
+    description: 'Recurring every two weeks',
+    days: 14,
+  },
+  BI_WEEKLY: {
+    label: 'Bi-Weekly',
+    description: 'Recurring every two weeks',
+    days: 14,
+  },
+  MONTHLY: {
+    label: 'Monthly',
+    description: 'Recurring every month',
+    days: 30,
+  },
+  BI_MONTHLY: {
+    label: 'Bi-Monthly',
+    description: 'Recurring every two months',
+    days: 60,
+  },
+  QUARTERLY: {
+    label: 'Quarterly',
+    description: 'Recurring every three months',
+    days: 90,
+  },
+  HALF_YEARLY: {
+    label: 'Half-Yearly',
+    description: 'Recurring every six months',
+    days: 180,
+  },
+  SEMI_ANNUAL: {
+    label: 'Semi-Annual',
+    description: 'Recurring every six months',
+    days: 180,
+  },
+  YEARLY: {
+    label: 'Yearly',
+    description: 'Recurring every year',
+    days: 365,
+  },
+  ANNUAL: {
+    label: 'Annual',
+    description: 'Recurring every year',
+    days: 365,
+  },
+  AS_PRESENTED: {
+    label: 'As Presented',
+    description: 'Collected as and when presented by the merchant',
+  },
+};
+
+const getMandateFrequencyLabel = (
+  frequencyCode: MandateFrequencyCode | string,
+): MandateFrequencyLabel => {
+  if (!frequencyCode)
+    throw new Error(
+      `Parameter 'frequencyCode' is invalid! The received value was: ${frequencyCode}.`,
+    );
+
+  const definition =
+    FREQUENCY_LABEL_MAP[(frequencyCode as string).toUpperCase()];
+  if (!definition)
+    throw new Error(
+      `Frequency code "${frequencyCode}" is not supported. ` +
+        `Supported codes: ${Object.keys(FREQUENCY_LABEL_MAP).join(', ')}.`,
+    );
+
+  return definition;
+};
+
+export default withErrorBoundary<typeof getMandateFrequencyLabel>(
+  getMandateFrequencyLabel,
+);

--- a/packages/i18nify-js/src/modules/mandate/index.ts
+++ b/packages/i18nify-js/src/modules/mandate/index.ts
@@ -1,0 +1,2 @@
+export { default as getMandateFrequencyLabel } from './getMandateFrequencyLabel';
+export type { MandateFrequencyLabel, MandateFrequencyCode } from './types';

--- a/packages/i18nify-js/src/modules/mandate/types.ts
+++ b/packages/i18nify-js/src/modules/mandate/types.ts
@@ -1,0 +1,19 @@
+export type MandateFrequencyCode =
+  | 'DAILY'
+  | 'WEEKLY'
+  | 'FORTNIGHTLY'
+  | 'BI_WEEKLY'
+  | 'MONTHLY'
+  | 'BI_MONTHLY'
+  | 'QUARTERLY'
+  | 'HALF_YEARLY'
+  | 'SEMI_ANNUAL'
+  | 'YEARLY'
+  | 'ANNUAL'
+  | 'AS_PRESENTED';
+
+export interface MandateFrequencyLabel {
+  label: string;
+  description: string;
+  days?: number; // approximate days between recurrences; undefined for variable-frequency codes
+}


### PR DESCRIPTION
## Summary
- **Go**: getMandateFrequencyLabel + tests
- **JS**: getMandateFrequencyLabel + types + tests

## Test plan
- [ ] Go tests: `cd packages/i18nify-go && go test ./modules/mandate/...`
- [ ] JS tests: `yarn workspace @razorpay/i18nify-js test --testPathPattern=mandate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)