### PR TITLE
feat(dateTime): add Go implementations for datetime utilities

### DIFF
--- a/packages/i18nify-go/modules/datetime/datetime.go
+++ b/packages/i18nify-go/modules/datetime/datetime.go
@@ -1,0 +1,57 @@
+// Package datetime provides locale-aware functions for formatting, computing,
+// and inspecting dates and times. It mirrors the i18nify-js dateTime module:
+//
+//   - FormatDateTime        — locale-aware date/time string formatting
+//   - GetRelativeTime       — human-readable relative time (e.g., "3 hours ago")
+//   - GetWeekdays           — ordered list of weekday names for a locale
+//   - GetTimeZoneByCountry  — timezone identifiers + UTC offsets for a country
+//   - GetTimezoneList       — all IANA timezones aggregated with observing countries
+//   - GetPrimaryTimezone    — primary (capital) IANA timezone for a country code
+//
+// Configuration data (locale ordering, separators, supported date formats) is
+// loaded at startup from the embedded i18nify-data/go/datetime package.
+// Timezone data is sourced from i18nify-data/go/country/metadata.
+package datetime
+
+import (
+	"fmt"
+
+	datetimeData "github.com/razorpay/i18nify/i18nify-data/go/datetime"
+	countryMetadata "github.com/razorpay/i18nify/i18nify-data/go/country/metadata"
+)
+
+// cachedDateTimeData is the datetime configuration loaded at init.
+var cachedDateTimeData *datetimeData.DateTimeData
+
+// cachedCountryMetadata is the country metadata used by GetTimeZoneByCountry.
+var cachedCountryMetadata *countryMetadata.CountryMetadataData
+
+// init loads both data packages once at package startup.
+// Panics on failure so misconfiguration is caught immediately,
+// matching the convention used by all other i18nify-go service modules.
+func init() {
+	dt, err := datetimeData.GetDateTimeData()
+	if err != nil {
+		panic(fmt.Sprintf("datetime: failed to load datetime data: %v", err))
+	}
+	cachedDateTimeData = dt
+
+	cm, err := countryMetadata.GetCountryMetadataData()
+	if err != nil {
+		panic(fmt.Sprintf("datetime: failed to load country metadata: %v", err))
+	}
+	cachedCountryMetadata = cm
+}
+
+// TimeZoneInfo holds details for a single IANA timezone identifier.
+type TimeZoneInfo struct {
+	// UTCOffset is the UTC offset string (e.g., "UTC +05:30").
+	UTCOffset string `json:"utc_offset"`
+}
+
+// TimezoneListEntry holds a timezone's UTC offset and the ISO 3166-1 alpha-2
+// country codes that observe it.
+type TimezoneListEntry struct {
+	UTCOffset string   `json:"utc_offset"`
+	Countries []string `json:"countries"`
+}

--- a/packages/i18nify-go/modules/datetime/format_date_time.go
+++ b/packages/i18nify-go/modules/datetime/format_date_time.go
@@ -1,0 +1,306 @@
+package datetime
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DateTimeMode controls which date/time components are included in the output.
+// Mirrors the dateTimeMode option of the JS formatDateTime function.
+type DateTimeMode string
+
+const (
+	// ModeDateOnly formats only the date portion (year, month, day).
+	ModeDateOnly DateTimeMode = "dateOnly"
+	// ModeTimeOnly formats only the time portion (hour, minute, second).
+	ModeTimeOnly DateTimeMode = "timeOnly"
+	// ModeDateTime formats both date and time.
+	ModeDateTime DateTimeMode = "dateTime"
+)
+
+// FieldStyle controls how an individual date/time field is rendered.
+// Mirrors the Intl.DateTimeFormatOptions field style values.
+type FieldStyle string
+
+const (
+	// StyleNumeric renders the field as a plain number (e.g., "1", "2006").
+	StyleNumeric FieldStyle = "numeric"
+	// Style2Digit renders the field zero-padded to two digits (e.g., "01", "06").
+	Style2Digit FieldStyle = "2-digit"
+	// StyleLong renders the field in full long form (e.g., "January", "Monday").
+	StyleLong FieldStyle = "long"
+	// StyleShort renders the field in abbreviated form (e.g., "Jan", "Mon").
+	StyleShort FieldStyle = "short"
+	// StyleNarrow renders the field in its narrowest form (e.g., "J").
+	StyleNarrow FieldStyle = "narrow"
+)
+
+// FormatDateTimeOptions configures FormatDateTime output.
+// It mirrors the options parameter of the JS formatDateTime function.
+type FormatDateTimeOptions struct {
+	// Locale is an IETF BCP 47 language tag (e.g., "en-US", "de", "ja").
+	// Defaults to "en-US" when empty.
+	Locale string
+
+	// DateTimeMode selects a preset set of components to include.
+	// Individual field styles below fall back to StyleNumeric if unset.
+	DateTimeMode DateTimeMode
+
+	// Individual field styles — each mirrors the corresponding
+	// Intl.DateTimeFormatOptions field. An empty value means "omit this field"
+	// unless DateTimeMode forces a default.
+	Year   FieldStyle
+	Month  FieldStyle
+	Day    FieldStyle
+	Hour   FieldStyle
+	Minute FieldStyle
+	Second FieldStyle
+
+	// Hour12, when non-nil, overrides the locale default:
+	//   true  → 12-hour clock (AM/PM)
+	//   false → 24-hour clock
+	Hour12 *bool
+}
+
+// dateOrderForLocale returns the date-field ordering ("MDY"/"DMY"/"YMD") for
+// the given locale, sourced from the embedded datetime data package.
+// Falls back to "DMY" when the locale is not found.
+func dateOrderForLocale(locale string) string {
+	orders := cachedDateTimeData.LocaleDateOrders
+
+	if ord, ok := orders[locale]; ok {
+		return ord
+	}
+	// Try primary language subtag (e.g., "zh-SG" → "zh").
+	if idx := strings.IndexByte(locale, '-'); idx > 0 {
+		if ord, ok := orders[locale[:idx]]; ok {
+			return ord
+		}
+	}
+	return "DMY"
+}
+
+// dateSepForLocale returns the conventional date separator for a locale,
+// sourced from the embedded datetime data package. Falls back to "/".
+func dateSepForLocale(locale string) string {
+	seps := cachedDateTimeData.LocaleDateSeparators
+
+	base := locale
+	if idx := strings.IndexByte(locale, '-'); idx > 0 {
+		base = locale[:idx]
+	}
+	if sep, ok := seps[base]; ok {
+		return sep
+	}
+	return "/"
+}
+
+// yearFmt maps a FieldStyle to Go's time.Format token for the year component.
+func yearFmt(s FieldStyle) string {
+	if s == Style2Digit {
+		return "06"
+	}
+	return "2006"
+}
+
+// monthFmt maps a FieldStyle to Go's time.Format token for the month component.
+func monthFmt(s FieldStyle) string {
+	switch s {
+	case StyleLong:
+		return "January"
+	case StyleShort, StyleNarrow:
+		return "Jan"
+	case Style2Digit:
+		return "01"
+	default: // numeric
+		return "1"
+	}
+}
+
+// dayFmt maps a FieldStyle to Go's time.Format token for the day component.
+func dayFmt(s FieldStyle) string {
+	if s == Style2Digit {
+		return "02"
+	}
+	return "2"
+}
+
+// hourFmt maps a FieldStyle + hour12 flag to Go's time.Format token for the hour.
+func hourFmt(s FieldStyle, hour12 bool) string {
+	if hour12 {
+		if s == Style2Digit {
+			return "03"
+		}
+		return "3"
+	}
+	// 24-hour: Go only provides zero-padded "15".
+	return "15"
+}
+
+// minuteFmt maps a FieldStyle to Go's time.Format token for the minute.
+func minuteFmt(s FieldStyle) string {
+	if s == StyleNumeric {
+		return "4"
+	}
+	return "04"
+}
+
+// secondFmt maps a FieldStyle to Go's time.Format token for the second.
+func secondFmt(s FieldStyle) string {
+	if s == StyleNumeric {
+		return "5"
+	}
+	return "05"
+}
+
+// FormatDateTime formats date according to the given locale and field options.
+// It mirrors the i18nify-js formatDateTime function from the dateTime module.
+//
+// Locale affects date-field ordering (MDY/DMY/YMD) and separator character,
+// as configured in i18nify-data/go/datetime/data/data.json.
+// Month and weekday names are always in English because Go's time package does
+// not embed CLDR locale data.
+//
+// Example — format as a US date:
+//
+//	s, err := FormatDateTime(t, FormatDateTimeOptions{
+//	    Locale:       "en-US",
+//	    DateTimeMode: ModeDateOnly,
+//	})
+//	// → "5/30/2026"
+func FormatDateTime(date time.Time, opts FormatDateTimeOptions) (string, error) {
+	locale := opts.Locale
+	if locale == "" {
+		locale = "en-US"
+	}
+
+	year := opts.Year
+	month := opts.Month
+	day := opts.Day
+	hour := opts.Hour
+	minute := opts.Minute
+	second := opts.Second
+
+	hour12 := false
+	if opts.Hour12 != nil {
+		hour12 = *opts.Hour12
+	}
+
+	// Apply DateTimeMode defaults — mirrors the JS switch-case block exactly.
+	switch opts.DateTimeMode {
+	case ModeDateOnly:
+		if year == "" {
+			year = StyleNumeric
+		}
+		if month == "" {
+			month = StyleNumeric
+		}
+		if day == "" {
+			day = StyleNumeric
+		}
+		hour, minute, second = "", "", ""
+
+	case ModeTimeOnly:
+		if hour == "" {
+			hour = StyleNumeric
+		}
+		if minute == "" {
+			minute = StyleNumeric
+		}
+		if second == "" {
+			second = StyleNumeric
+		}
+		year, month, day = "", "", ""
+
+	case ModeDateTime:
+		if year == "" {
+			year = StyleNumeric
+		}
+		if month == "" {
+			month = StyleNumeric
+		}
+		if day == "" {
+			day = StyleNumeric
+		}
+		if hour == "" {
+			hour = StyleNumeric
+		}
+		if minute == "" {
+			minute = StyleNumeric
+		}
+		if second == "" {
+			second = StyleNumeric
+		}
+	}
+
+	var segments []string
+
+	// ── Date segment ─────────────────────────────────────────────────────────
+	if year != "" || month != "" || day != "" {
+		sep := dateSepForLocale(locale)
+		order := dateOrderForLocale(locale)
+
+		var dp []string
+		switch order {
+		case "MDY":
+			if month != "" {
+				dp = append(dp, monthFmt(month))
+			}
+			if day != "" {
+				dp = append(dp, dayFmt(day))
+			}
+			if year != "" {
+				dp = append(dp, yearFmt(year))
+			}
+		case "YMD":
+			if year != "" {
+				dp = append(dp, yearFmt(year))
+			}
+			if month != "" {
+				dp = append(dp, monthFmt(month))
+			}
+			if day != "" {
+				dp = append(dp, dayFmt(day))
+			}
+		default: // DMY
+			if day != "" {
+				dp = append(dp, dayFmt(day))
+			}
+			if month != "" {
+				dp = append(dp, monthFmt(month))
+			}
+			if year != "" {
+				dp = append(dp, yearFmt(year))
+			}
+		}
+		if len(dp) > 0 {
+			segments = append(segments, strings.Join(dp, sep))
+		}
+	}
+
+	// ── Time segment ─────────────────────────────────────────────────────────
+	if hour != "" || minute != "" || second != "" {
+		var tp []string
+		if hour != "" {
+			tp = append(tp, hourFmt(hour, hour12))
+		}
+		if minute != "" {
+			tp = append(tp, minuteFmt(minute))
+		}
+		if second != "" {
+			tp = append(tp, secondFmt(second))
+		}
+		timeLayout := strings.Join(tp, ":")
+		if hour12 {
+			timeLayout += " PM"
+		}
+		segments = append(segments, timeLayout)
+	}
+
+	if len(segments) == 0 {
+		return "", fmt.Errorf("formatDateTime: no date or time components specified in options")
+	}
+
+	return date.Format(strings.Join(segments, " ")), nil
+}

--- a/packages/i18nify-go/modules/datetime/format_from_unix.go
+++ b/packages/i18nify-go/modules/datetime/format_from_unix.go
@@ -1,0 +1,55 @@
+package datetime
+
+import (
+	"fmt"
+	"time"
+)
+
+// FormatFromUnixOptions extends FormatDateTimeOptions with a timezone setting.
+type FormatFromUnixOptions struct {
+	FormatDateTimeOptions
+
+	// Timezone is an IANA timezone name (e.g., "America/New_York", "Asia/Kolkata").
+	// Defaults to "UTC" when empty.
+	Timezone string
+}
+
+// FormatFromUnix converts a Unix timestamp (seconds since epoch) to a
+// timezone-aware formatted datetime string.
+//
+// It returns an error when the timezone identifier is not recognised by the
+// system timezone database. When no FormatFromUnixOptions are supplied the
+// output uses ModeDateTime with the en-US locale in UTC.
+//
+// Example:
+//
+//	s, err := FormatFromUnix(1609459200, FormatFromUnixOptions{
+//	    Timezone: "America/New_York",
+//	    FormatDateTimeOptions: FormatDateTimeOptions{DateTimeMode: ModeDateTime, Locale: "en-US"},
+//	})
+//	// → "12/31/2020 19:0:0"  (2021-01-01 00:00 UTC = 2020-12-31 19:00 EST)
+func FormatFromUnix(unixTimestamp int64, opts ...FormatFromUnixOptions) (string, error) {
+	opt := FormatFromUnixOptions{}
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	timezone := opt.Timezone
+	if timezone == "" {
+		timezone = "UTC"
+	}
+
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		return "", fmt.Errorf("formatFromUnix: invalid timezone %q: %w", timezone, err)
+	}
+
+	t := time.Unix(unixTimestamp, 0).In(loc)
+
+	fmtOpts := opt.FormatDateTimeOptions
+	if fmtOpts.DateTimeMode == "" {
+		fmtOpts.DateTimeMode = ModeDateTime
+	}
+
+	return FormatDateTime(t, fmtOpts)
+}

--- a/packages/i18nify-go/modules/datetime/get_financial_year.go
+++ b/packages/i18nify-go/modules/datetime/get_financial_year.go
@@ -1,0 +1,102 @@
+package datetime
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FYLabelFormat controls the financial year label style.
+type FYLabelFormat string
+
+const (
+	FYLabelShort FYLabelFormat = "short" // "2024-25"
+	FYLabelLong  FYLabelFormat = "long"  // "2024-2025"
+	FYLabelFY    FYLabelFormat = "fy"    // "FY2025"
+)
+
+// GetFinancialYearOptions holds optional overrides for GetFinancialYear.
+type GetFinancialYearOptions struct {
+	LabelFormat FYLabelFormat
+}
+
+type fyCountryConfig struct {
+	startMonth  int
+	labelFormat FYLabelFormat
+}
+
+// fyConfigMap maps ISO 3166-1 alpha-2 country codes to their FY convention.
+var fyConfigMap = map[string]fyCountryConfig{
+	// April 1 → March 31 — label "2024-25"
+	"IN": {4, FYLabelShort},
+	"JP": {4, FYLabelShort},
+	"GB": {4, FYLabelShort},
+	"CA": {4, FYLabelShort},
+	"NZ": {4, FYLabelShort},
+	"SG": {4, FYLabelShort},
+	"ZA": {4, FYLabelShort},
+	// July 1 → June 30 — label "2024-25"
+	"AU": {7, FYLabelShort},
+	"BD": {7, FYLabelShort},
+	"PK": {7, FYLabelShort},
+	// October 1 → September 30 — label "FY2025"
+	"US": {10, FYLabelFY},
+}
+
+// GetFinancialYear returns the financial year label for date in the given country.
+//
+// Supported label formats (override via opts.LabelFormat):
+//   - "short" (default for most countries): "2024-25"
+//   - "long":  "2024-2025"
+//   - "fy"   (default for US):  "FY2025"
+//
+// Supported country codes: IN, JP, GB, CA, NZ, SG, ZA, AU, BD, PK, US.
+//
+// Examples:
+//
+//	GetFinancialYear(time.Date(2024, 11, 15, 0, 0, 0, 0, time.UTC), "IN")  → "2024-25"
+//	GetFinancialYear(time.Date(2024, 2, 10, 0, 0, 0, 0, time.UTC),  "IN")  → "2023-24"
+//	GetFinancialYear(time.Date(2024, 11, 15, 0, 0, 0, 0, time.UTC), "US")  → "FY2025"
+func GetFinancialYear(date time.Time, countryCode string, opts ...GetFinancialYearOptions) (string, error) {
+	if strings.TrimSpace(countryCode) == "" {
+		return "", fmt.Errorf("getFinancialYear: country code must not be empty")
+	}
+
+	code := strings.ToUpper(strings.TrimSpace(countryCode))
+	cfg, ok := fyConfigMap[code]
+	if !ok {
+		supported := make([]string, 0, len(fyConfigMap))
+		for k := range fyConfigMap {
+			supported = append(supported, k)
+		}
+		return "", fmt.Errorf(
+			"getFinancialYear: country code %q is not supported; supported: %s",
+			countryCode, strings.Join(supported, ", "),
+		)
+	}
+
+	labelFormat := cfg.labelFormat
+	if len(opts) > 0 && opts[0].LabelFormat != "" {
+		labelFormat = opts[0].LabelFormat
+	}
+
+	year := date.Year()
+	month := int(date.Month()) // time.Month is 1-indexed
+
+	fyStartYear := year
+	if month < cfg.startMonth {
+		fyStartYear = year - 1
+	}
+	fyEndYear := fyStartYear + 1
+
+	switch labelFormat {
+	case FYLabelShort:
+		return fmt.Sprintf("%d-%02d", fyStartYear, fyEndYear%100), nil
+	case FYLabelLong:
+		return fmt.Sprintf("%d-%d", fyStartYear, fyEndYear), nil
+	case FYLabelFY:
+		return fmt.Sprintf("FY%d", fyEndYear), nil
+	default:
+		return "", fmt.Errorf("getFinancialYear: unknown label format %q", labelFormat)
+	}
+}

--- a/packages/i18nify-go/modules/datetime/get_ordinal_suffix.go
+++ b/packages/i18nify-go/modules/datetime/get_ordinal_suffix.go
@@ -1,0 +1,37 @@
+package datetime
+
+import "fmt"
+
+// GetOrdinalSuffix returns the English ordinal suffix for n: "st", "nd", "rd", or "th".
+//
+// The teen exception applies: 11, 12, and 13 always return "th" regardless of
+// the last digit (e.g. 111 → "th", 112 → "th", 113 → "th").
+// Returns an error when n < 1.
+//
+// Examples:
+//
+//	GetOrdinalSuffix(1)   → "st"
+//	GetOrdinalSuffix(11)  → "th"  // teen exception
+//	GetOrdinalSuffix(21)  → "st"
+//	GetOrdinalSuffix(111) → "th"  // teen exception via n%100
+func GetOrdinalSuffix(n int) (string, error) {
+	if n < 1 {
+		return "", fmt.Errorf("getOrdinalSuffix: n must be a positive integer, got %d", n)
+	}
+
+	lastTwo := n % 100
+	if lastTwo >= 11 && lastTwo <= 13 {
+		return "th", nil
+	}
+
+	switch n % 10 {
+	case 1:
+		return "st", nil
+	case 2:
+		return "nd", nil
+	case 3:
+		return "rd", nil
+	default:
+		return "th", nil
+	}
+}

--- a/packages/i18nify-go/modules/datetime/get_primary_timezone.go
+++ b/packages/i18nify-go/modules/datetime/get_primary_timezone.go
@@ -1,0 +1,50 @@
+package datetime
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetPrimaryTimezone returns the primary IANA timezone identifier for the given
+// ISO 3166-1 alpha-2 country code (case-insensitive).
+//
+// For single-timezone countries the result is their only timezone.
+// For multi-timezone countries (e.g., "US", "RU", "AU") the result is the
+// capital city's timezone, sourced from the timezone_of_capital field in the
+// embedded country metadata.
+//
+// Errors are returned for:
+//   - an empty country code
+//   - a code not present in the metadata
+//
+// Example:
+//
+//	tz, err := GetPrimaryTimezone("IN")
+//	// → "Asia/Kolkata", nil
+//
+//	tz, err := GetPrimaryTimezone("US")
+//	// → "America/New_York", nil
+func GetPrimaryTimezone(countryCode string) (string, error) {
+	if strings.TrimSpace(countryCode) == "" {
+		return "", fmt.Errorf("getPrimaryTimezone: country code must not be empty")
+	}
+
+	code := strings.ToUpper(strings.TrimSpace(countryCode))
+
+	if cachedCountryMetadata == nil {
+		return "", fmt.Errorf("getPrimaryTimezone: country metadata not loaded")
+	}
+
+	metadataMap := cachedCountryMetadata.GetMetadataInformation()
+	countryMeta, exists := metadataMap[code]
+	if !exists {
+		return "", fmt.Errorf("getPrimaryTimezone: country code %q not found", code)
+	}
+
+	tz := countryMeta.GetTimezoneOfCapital()
+	if tz == "" {
+		return "", fmt.Errorf("getPrimaryTimezone: no primary timezone for country code %q", code)
+	}
+
+	return tz, nil
+}

--- a/packages/i18nify-go/modules/datetime/get_relative_time.go
+++ b/packages/i18nify-go/modules/datetime/get_relative_time.go
@@ -1,0 +1,183 @@
+package datetime
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+// GetRelativeTimeOptions configures GetRelativeTime output.
+// It mirrors the options parameter of the JS getRelativeTime function.
+type GetRelativeTimeOptions struct {
+	// Locale is an IETF BCP 47 language tag. Defaults to "en-US".
+	Locale string
+
+	// BaseDate is the reference point for the relative calculation.
+	// When zero-valued, the current time (time.Now()) is used — matching JS behaviour
+	// where options.baseDate defaults to new Date().
+	BaseDate time.Time
+
+	// Numeric controls whether the output always uses a numeral ("always") or
+	// uses natural-language forms where possible ("auto").
+	// Mirrors Intl.RelativeTimeFormatOptions.numeric. Defaults to "auto".
+	Numeric string
+
+	// Style controls output verbosity: "long" (default), "short", or "narrow".
+	// Mirrors Intl.RelativeTimeFormatOptions.style.
+	Style string
+}
+
+// Time-unit thresholds in seconds — exact copies of the JS constants.
+const (
+	thresholdMinute = 60
+	thresholdHour   = thresholdMinute * 60
+	thresholdDay    = thresholdHour * 24
+	thresholdWeek   = thresholdDay * 7
+	thresholdMonth  = thresholdDay * 30
+	thresholdYear   = thresholdDay * 365
+)
+
+// relUnit is the resolved time unit used when formatting.
+type relUnit string
+
+const (
+	relSecond relUnit = "second"
+	relMinute relUnit = "minute"
+	relHour   relUnit = "hour"
+	relDay    relUnit = "day"
+	relWeek   relUnit = "week"
+	relMonth  relUnit = "month"
+	relYear   relUnit = "year"
+)
+
+// relTemplates is the lookup table for English relative-time strings.
+// Keys follow the pattern "<unit>:<past|future>[:<value>]":
+//   - The two-part key is the plural template (e.g., "3 days ago").
+//   - The three-part key (with value) is a natural-language override for
+//     Numeric="auto" (e.g., "yesterday", "last week").
+//
+// Only English entries are included. Additional locales can be added as needed.
+var relTemplates = map[string]string{
+	// ── plural templates ───────────────────────────────────────────────────
+	"second:past":  "%d seconds ago",
+	"second:future": "in %d seconds",
+	"minute:past":  "%d minutes ago",
+	"minute:future": "in %d minutes",
+	"hour:past":    "%d hours ago",
+	"hour:future":  "in %d hours",
+	"day:past":     "%d days ago",
+	"day:future":   "in %d days",
+	"week:past":    "%d weeks ago",
+	"week:future":  "in %d weeks",
+	"month:past":   "%d months ago",
+	"month:future": "in %d months",
+	"year:past":    "%d years ago",
+	"year:future":  "in %d years",
+
+	// ── natural-language singular overrides (Numeric="auto") ───────────────
+	"second:past:1":  "a second ago",
+	"second:future:1": "in a second",
+	"minute:past:1":  "a minute ago",
+	"minute:future:1": "in a minute",
+	"hour:past:1":    "an hour ago",
+	"hour:future:1":  "in an hour",
+	"day:past:1":     "yesterday",
+	"day:future:1":   "tomorrow",
+	"week:past:1":    "last week",
+	"week:future:1":  "next week",
+	"month:past:1":   "last month",
+	"month:future:1": "next month",
+	"year:past:1":    "last year",
+	"year:future:1":  "next year",
+}
+
+// GetRelativeTime returns a locale-aware string that describes the time
+// elapsed between date and a base date (defaults to now).
+//
+// The selection of time unit mirrors the JS implementation exactly:
+//
+//	|diff| < 60 s  → "second"
+//	|diff| < 3600 s → "minute"
+//	|diff| < 86400 s → "hour"
+//	|diff| < 604800 s → "day"
+//	|diff| < 2592000 s (30 d) → "week"
+//	|diff| < 31536000 s (365 d) → "month"
+//	otherwise → "year"
+//
+// Example:
+//
+//	s, err := GetRelativeTime(yesterday, GetRelativeTimeOptions{Locale: "en-US"})
+//	// → "yesterday"  (Numeric="auto" default)
+func GetRelativeTime(date time.Time, opts GetRelativeTimeOptions) (string, error) {
+	locale := opts.Locale
+	if locale == "" {
+		locale = "en-US"
+	}
+
+	baseDate := opts.BaseDate
+	if baseDate.IsZero() {
+		baseDate = time.Now()
+	}
+
+	numeric := strings.ToLower(opts.Numeric)
+	if numeric == "" {
+		numeric = "auto"
+	}
+
+	diffSeconds := date.Sub(baseDate).Seconds()
+	abs := math.Abs(diffSeconds)
+
+	// Determine unit — mirrors JS thresholds exactly.
+	var unit relUnit
+	var rawValue float64
+
+	switch {
+	case abs < float64(thresholdMinute):
+		unit, rawValue = relSecond, diffSeconds
+	case abs < float64(thresholdHour):
+		unit, rawValue = relMinute, diffSeconds/thresholdMinute
+	case abs < float64(thresholdDay):
+		unit, rawValue = relHour, diffSeconds/thresholdHour
+	case abs < float64(thresholdWeek):
+		unit, rawValue = relDay, diffSeconds/thresholdDay
+	case abs < float64(thresholdMonth):
+		unit, rawValue = relWeek, diffSeconds/thresholdWeek
+	case abs < float64(thresholdYear):
+		unit, rawValue = relMonth, diffSeconds/thresholdMonth
+	default:
+		unit, rawValue = relYear, diffSeconds/thresholdYear
+	}
+
+	rounded := int(math.Round(rawValue))
+	direction := "future"
+	if rounded <= 0 {
+		direction = "past"
+		rounded = -rounded
+	}
+
+	result, err := lookupRelativeTemplate(unit, direction, rounded, numeric)
+	if err != nil {
+		return "", fmt.Errorf("getRelativeTime: %w", err)
+	}
+	return result, nil
+}
+
+// lookupRelativeTemplate returns the formatted relative time string.
+func lookupRelativeTemplate(unit relUnit, direction string, value int, numeric string) (string, error) {
+	// Natural-language singular override when numeric != "always".
+	if numeric != "always" {
+		singularKey := fmt.Sprintf("%s:%s:%d", unit, direction, value)
+		if tmpl, ok := relTemplates[singularKey]; ok {
+			return tmpl, nil
+		}
+	}
+
+	// Plural / numeric template.
+	pluralKey := fmt.Sprintf("%s:%s", unit, direction)
+	if tmpl, ok := relTemplates[pluralKey]; ok {
+		return fmt.Sprintf(tmpl, value), nil
+	}
+
+	return "", fmt.Errorf("no template for unit=%s direction=%s", unit, direction)
+}

--- a/packages/i18nify-go/modules/datetime/get_timezone_by_country.go
+++ b/packages/i18nify-go/modules/datetime/get_timezone_by_country.go
@@ -1,0 +1,57 @@
+package datetime
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetTimeZoneByCountry returns the timezone identifiers and their UTC offsets
+// for the given ISO 3166-1 alpha-2 country code (case-insensitive).
+//
+// The returned map is keyed by IANA timezone identifier (e.g., "Asia/Kolkata")
+// and each value carries the UTC offset string (e.g., "+05:30").
+//
+// When a country observes multiple timezones (e.g., "US", "RU", "AU") the
+// full set is returned. Data is sourced from the embedded country metadata
+// package (i18nify-data/go/country/metadata).
+//
+// Errors are returned for:
+//   - an empty country code
+//   - a code not present in the metadata
+//   - a code present in the metadata but with no timezone entries
+//
+// Example:
+//
+//	tzs, err := GetTimeZoneByCountry("IN")
+//	// → map["Asia/Kolkata": {UTCOffset: "+05:30"}]
+func GetTimeZoneByCountry(countryCode string) (map[string]TimeZoneInfo, error) {
+	if strings.TrimSpace(countryCode) == "" {
+		return nil, fmt.Errorf("getTimeZoneByCountry: country code must not be empty")
+	}
+
+	code := strings.ToUpper(strings.TrimSpace(countryCode))
+
+	if cachedCountryMetadata == nil {
+		return nil, fmt.Errorf("getTimeZoneByCountry: country metadata not loaded")
+	}
+
+	metadataMap := cachedCountryMetadata.GetMetadataInformation()
+	countryMeta, exists := metadataMap[code]
+	if !exists {
+		return nil, fmt.Errorf("getTimeZoneByCountry: country code %q not found", code)
+	}
+
+	rawTimezones := countryMeta.GetTimezones()
+	if len(rawTimezones) == 0 {
+		return nil, fmt.Errorf("getTimeZoneByCountry: no timezone data for country code %q", code)
+	}
+
+	result := make(map[string]TimeZoneInfo, len(rawTimezones))
+	for tzKey, tzVal := range rawTimezones {
+		if tzVal != nil {
+			result[tzKey] = TimeZoneInfo{UTCOffset: tzVal.GetUtcOffset()}
+		}
+	}
+
+	return result, nil
+}

--- a/packages/i18nify-go/modules/datetime/get_timezone_list.go
+++ b/packages/i18nify-go/modules/datetime/get_timezone_list.go
@@ -1,0 +1,66 @@
+package datetime
+
+import "fmt"
+
+// GetTimezoneList aggregates all IANA timezone identifiers across every country
+// in the metadata. Each entry carries the UTC offset and the list of ISO 3166-1
+// alpha-2 country codes that observe that timezone.
+//
+// Countries sharing a timezone (e.g., multiple Caribbean nations using
+// "America/Port_of_Spain") are all listed under that timezone's entry.
+//
+// This mirrors the JS getTimezoneList implementation; the only difference is
+// that Go reads from the embedded country metadata loaded at package init
+// instead of fetching over HTTP.
+//
+// Example:
+//
+//	list, err := GetTimezoneList()
+//	list["Asia/Kolkata"]
+//	// → {UTCOffset: "UTC +05:30", Countries: ["IN"]}
+//
+//	list["America/New_York"]
+//	// → {UTCOffset: "UTC -05:00", Countries: ["US", ...]}
+func GetTimezoneList() (map[string]TimezoneListEntry, error) {
+	if cachedCountryMetadata == nil {
+		return nil, fmt.Errorf("getTimezoneList: country metadata not loaded")
+	}
+
+	metadataMap := cachedCountryMetadata.GetMetadataInformation()
+	result := make(map[string]TimezoneListEntry)
+
+	for countryCode, countryMeta := range metadataMap {
+		if countryMeta == nil {
+			continue
+		}
+
+		for tzKey, tzVal := range countryMeta.GetTimezones() {
+			if tzVal == nil {
+				continue
+			}
+
+			entry, exists := result[tzKey]
+			if !exists {
+				entry = TimezoneListEntry{
+					UTCOffset: tzVal.GetUtcOffset(),
+					Countries: []string{},
+				}
+			}
+
+			seen := false
+			for _, cc := range entry.Countries {
+				if cc == countryCode {
+					seen = true
+					break
+				}
+			}
+			if !seen {
+				entry.Countries = append(entry.Countries, countryCode)
+			}
+
+			result[tzKey] = entry
+		}
+	}
+
+	return result, nil
+}

--- a/packages/i18nify-go/modules/datetime/get_weekdays.go
+++ b/packages/i18nify-go/modules/datetime/get_weekdays.go
@@ -1,0 +1,79 @@
+package datetime
+
+import (
+	"fmt"
+	"time"
+)
+
+// WeekdayStyle controls the display length of weekday names.
+// Mirrors the weekday option of Intl.DateTimeFormatOptions.
+type WeekdayStyle string
+
+const (
+	// WeekdayLong returns the full weekday name (e.g., "Monday").
+	WeekdayLong WeekdayStyle = "long"
+	// WeekdayShort returns the abbreviated weekday name (e.g., "Mon").
+	WeekdayShort WeekdayStyle = "short"
+	// WeekdayNarrow returns the first letter of the short name (e.g., "M").
+	WeekdayNarrow WeekdayStyle = "narrow"
+)
+
+// GetWeekdaysOptions configures GetWeekdays output.
+type GetWeekdaysOptions struct {
+	// Locale is an IETF BCP 47 language tag. Defaults to "en-US".
+	// Note: Go's time package always produces English weekday names;
+	// locale is accepted for API consistency but does not affect output text.
+	Locale string
+
+	// Weekday controls the display format. Defaults to WeekdayLong.
+	Weekday WeekdayStyle
+}
+
+// sundayEpoch is January 4, 1970, which was a Sunday.
+// Starting from a known Sunday and iterating seven days reproduces the
+// same full-week sequence as the JS implementation, which uses
+// new Date(1970, 0, 4 + i) for i in [0, 6].
+var sundayEpoch = time.Date(1970, time.January, 4, 0, 0, 0, 0, time.UTC)
+
+// GetWeekdays returns a slice of seven weekday names starting from Sunday.
+// It mirrors the i18nify-js getWeekdays function.
+//
+// The returned slice always has exactly 7 elements ordered
+// [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday].
+//
+// Note: Go's time.Format always produces English names. For fully localised
+// weekday names, use a CLDR-backed library.
+//
+// Example:
+//
+//	days, err := GetWeekdays(GetWeekdaysOptions{Weekday: WeekdayShort})
+//	// → ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+func GetWeekdays(opts GetWeekdaysOptions) ([]string, error) {
+	style := opts.Weekday
+	if style == "" {
+		style = WeekdayLong
+	}
+
+	var formatFn func(time.Time) string
+	switch style {
+	case WeekdayLong:
+		formatFn = func(t time.Time) string { return t.Format("Monday") }
+	case WeekdayShort:
+		formatFn = func(t time.Time) string { return t.Format("Mon") }
+	case WeekdayNarrow:
+		// Go has no built-in narrow weekday token; return the first letter of
+		// the abbreviated name, matching the JS "narrow" behaviour.
+		formatFn = func(t time.Time) string { return t.Format("Mon")[:1] }
+	default:
+		return nil, fmt.Errorf(
+			"getWeekdays: unsupported weekday style %q; valid values are 'long', 'short', 'narrow'",
+			style,
+		)
+	}
+
+	weekdays := make([]string, 7)
+	for i := 0; i < 7; i++ {
+		weekdays[i] = formatFn(sundayEpoch.AddDate(0, 0, i))
+	}
+	return weekdays, nil
+}

--- a/packages/i18nify-js/src/modules/dateTime/__tests__/formatFromUnix.test.ts
+++ b/packages/i18nify-js/src/modules/dateTime/__tests__/formatFromUnix.test.ts
@@ -1,0 +1,140 @@
+import formatFromUnix from '../formatFromUnix';
+
+jest.mock('@internationalized/date', () => ({
+  DateFormatter: jest
+    .fn()
+    .mockImplementation(
+      (locale: string, options: Intl.DateTimeFormatOptions) => ({
+        format: jest.fn().mockImplementation((date: Date) => {
+          const formatter = new Intl.DateTimeFormat(locale, options);
+          return formatter.format(new Date(date));
+        }),
+      }),
+    ),
+}));
+
+const norm = (s: string) => s.replace(/\s+/g, ' ');
+
+describe('formatFromUnix', () => {
+  describe('basic formatting', () => {
+    it('formats Unix 0 in UTC as en-US datetime', () => {
+      const result = formatFromUnix(0, { timezone: 'UTC', locale: 'en-US' });
+      expect(norm(result)).toBe('1/1/1970, 12:00:00 AM');
+    });
+
+    it('formats a modern timestamp in UTC', () => {
+      // 1609459200 = 2021-01-01T00:00:00.000Z
+      const result = formatFromUnix(1609459200, {
+        timezone: 'UTC',
+        locale: 'en-US',
+      });
+      expect(norm(result)).toBe('1/1/2021, 12:00:00 AM');
+    });
+
+    it('returns a string for any finite integer', () => {
+      expect(typeof formatFromUnix(1700000000, { timezone: 'UTC' })).toBe(
+        'string',
+      );
+    });
+  });
+
+  describe('timezone conversion', () => {
+    it('shifts date when timezone is behind UTC (America/New_York)', () => {
+      // Unix 0 in UTC = 1970-01-01 00:00:00 → EST (UTC-5) = 1969-12-31 19:00:00
+      const result = formatFromUnix(0, {
+        timezone: 'America/New_York',
+        locale: 'en-US',
+      });
+      expect(norm(result)).toBe('12/31/1969, 7:00:00 PM');
+    });
+
+    it('shifts time ahead when timezone is ahead of UTC (Asia/Kolkata)', () => {
+      // Unix 0 in UTC+5:30 = 1970-01-01 05:30:00 IST
+      const result = formatFromUnix(0, {
+        timezone: 'Asia/Kolkata',
+        locale: 'en-US',
+      });
+      expect(norm(result)).toBe('1/1/1970, 5:30:00 AM');
+    });
+
+    it('produces different outputs for different timezones on the same timestamp', () => {
+      const utc = formatFromUnix(1700000000, { timezone: 'UTC' });
+      const ny = formatFromUnix(1700000000, { timezone: 'America/New_York' });
+      expect(utc).not.toBe(ny);
+    });
+  });
+
+  describe('custom intlOptions', () => {
+    it('honours dateOnly via intlOptions', () => {
+      const result = formatFromUnix(1609459200, {
+        timezone: 'UTC',
+        locale: 'en-US',
+        intlOptions: {
+          year: 'numeric',
+          month: 'numeric',
+          day: 'numeric',
+        },
+      });
+      expect(norm(result)).toBe('1/1/2021');
+    });
+
+    it('honours 24-hour clock via intlOptions', () => {
+      // 1609459200 = midnight UTC → 00:00:00 in 24h
+      // hourCycle: 'h23' explicitly forces 0–23 range (hour12: false alone
+      // returns '24:00:00' on newer ICU versions)
+      const result = formatFromUnix(1609459200, {
+        timezone: 'UTC',
+        locale: 'en-US',
+        intlOptions: {
+          hour: 'numeric',
+          minute: 'numeric',
+          second: 'numeric',
+          hourCycle: 'h23',
+        },
+      });
+      expect(norm(result)).toBe('00:00:00');
+    });
+
+    it('explicit timezone in intlOptions is overridden by the timezone parameter', () => {
+      const withParam = formatFromUnix(1609459200, {
+        timezone: 'UTC',
+        locale: 'en-US',
+        intlOptions: {
+          timeZone: 'America/New_York',
+          year: 'numeric',
+          month: 'numeric',
+          day: 'numeric',
+        },
+      });
+      // timezone: 'UTC' must win → date stays 1/1/2021 not 12/31/2020
+      expect(norm(withParam)).toBe('1/1/2021');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it.each([NaN, Infinity, -Infinity])(
+      'throws for non-finite value %s',
+      (ts) => {
+        expect(() => formatFromUnix(ts, { timezone: 'UTC' })).toThrow(
+          /Invalid Unix timestamp/,
+        );
+      },
+    );
+
+    it('throws when timezone is invalid', () => {
+      expect(() => formatFromUnix(0, { timezone: 'Not/A/Timezone' })).toThrow();
+    });
+  });
+
+  describe('negative timestamps (pre-1970)', () => {
+    it('handles negative Unix timestamps', () => {
+      // -1 = 1969-12-31T23:59:59 UTC
+      const result = formatFromUnix(-1, {
+        timezone: 'UTC',
+        locale: 'en-US',
+        intlOptions: { year: 'numeric', month: 'numeric', day: 'numeric' },
+      });
+      expect(norm(result)).toBe('12/31/1969');
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/dateTime/__tests__/getFinancialYear.test.ts
+++ b/packages/i18nify-js/src/modules/dateTime/__tests__/getFinancialYear.test.ts
@@ -1,0 +1,113 @@
+import getFinancialYear from '../getFinancialYear';
+
+describe('getFinancialYear', () => {
+  // India — April 1 → March 31
+  describe('India (Apr–Mar)', () => {
+    it('Apr 1 → FY starts that year', () => {
+      expect(getFinancialYear(new Date(2024, 3, 1), 'IN')).toBe('2024-25');
+    });
+    it('Nov 15 → same FY as April', () => {
+      expect(getFinancialYear(new Date(2024, 10, 15), 'IN')).toBe('2024-25');
+    });
+    it('Mar 31 → FY started previous April', () => {
+      expect(getFinancialYear(new Date(2024, 2, 31), 'IN')).toBe('2023-24');
+    });
+    it('Jan 1 → FY started previous April', () => {
+      expect(getFinancialYear(new Date(2025, 0, 1), 'IN')).toBe('2024-25');
+    });
+    it('string date input', () => {
+      expect(getFinancialYear('2024-11-15', 'IN')).toBe('2024-25');
+    });
+    it('lowercase country code is normalised', () => {
+      expect(getFinancialYear(new Date(2024, 10, 15), 'in')).toBe('2024-25');
+    });
+  });
+
+  // Australia — July 1 → June 30
+  describe('Australia (Jul–Jun)', () => {
+    it('Jul 1 → FY starts that year', () => {
+      expect(getFinancialYear(new Date(2024, 6, 1), 'AU')).toBe('2024-25');
+    });
+    it('Jun 30 → FY started previous July', () => {
+      expect(getFinancialYear(new Date(2024, 5, 30), 'AU')).toBe('2023-24');
+    });
+  });
+
+  // US — October 1 → September 30 (fy format)
+  describe('US (Oct–Sep, FY format)', () => {
+    it('Oct 1 → FY ends next year', () => {
+      expect(getFinancialYear(new Date(2024, 9, 1), 'US')).toBe('FY2025');
+    });
+    it('Sep 30 → FY ends that year', () => {
+      expect(getFinancialYear(new Date(2024, 8, 30), 'US')).toBe('FY2024');
+    });
+    it('Jan 1 → FY end year is same calendar year', () => {
+      expect(getFinancialYear(new Date(2025, 0, 1), 'US')).toBe('FY2025');
+    });
+  });
+
+  // Other supported countries
+  describe('other supported countries', () => {
+    it('GB (Apr–Mar) same as IN', () => {
+      expect(getFinancialYear(new Date(2024, 10, 15), 'GB')).toBe('2024-25');
+    });
+    it('Pakistan (Jul–Jun)', () => {
+      expect(getFinancialYear(new Date(2024, 10, 15), 'PK')).toBe('2024-25');
+    });
+    it('Japan (Apr–Mar)', () => {
+      expect(getFinancialYear(new Date(2024, 2, 31), 'JP')).toBe('2023-24');
+    });
+  });
+
+  // labelFormat overrides
+  describe('labelFormat override', () => {
+    it('long format: 2024-2025', () => {
+      expect(
+        getFinancialYear(new Date(2024, 10, 15), 'IN', { labelFormat: 'long' }),
+      ).toBe('2024-2025');
+    });
+    it('fy format: FY2025', () => {
+      expect(
+        getFinancialYear(new Date(2024, 10, 15), 'IN', { labelFormat: 'fy' }),
+      ).toBe('FY2025');
+    });
+    it('short override on US', () => {
+      expect(
+        getFinancialYear(new Date(2024, 9, 1), 'US', { labelFormat: 'short' }),
+      ).toBe('2024-25');
+    });
+    it('long override on US', () => {
+      expect(
+        getFinancialYear(new Date(2024, 9, 1), 'US', { labelFormat: 'long' }),
+      ).toBe('2024-2025');
+    });
+  });
+
+  // Cross-century edge case
+  describe('century boundary', () => {
+    it('2-digit year component wraps correctly at century (2099→00)', () => {
+      expect(getFinancialYear(new Date(2099, 10, 15), 'IN')).toBe('2099-00');
+    });
+  });
+
+  // Error cases
+  describe('error handling', () => {
+    it('throws for unsupported country', () => {
+      expect(() => getFinancialYear(new Date(), 'DE')).toThrow('not supported');
+    });
+    it('throws for unknown country code', () => {
+      expect(() => getFinancialYear(new Date(), 'XX')).toThrow('not supported');
+    });
+    it('throws for missing date', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => getFinancialYear(null as any, 'IN')).toThrow(
+        "'date' is invalid",
+      );
+    });
+    it('throws for empty countryCode', () => {
+      expect(() => getFinancialYear(new Date(), '')).toThrow(
+        "'countryCode' is invalid",
+      );
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/dateTime/__tests__/getOrdinalSuffix.test.ts
+++ b/packages/i18nify-js/src/modules/dateTime/__tests__/getOrdinalSuffix.test.ts
@@ -1,0 +1,46 @@
+import getOrdinalSuffix from '../getOrdinalSuffix';
+
+describe('getOrdinalSuffix', () => {
+  describe('basic suffixes', () => {
+    it('1 → "st"', () => expect(getOrdinalSuffix(1)).toBe('st'));
+    it('2 → "nd"', () => expect(getOrdinalSuffix(2)).toBe('nd'));
+    it('3 → "rd"', () => expect(getOrdinalSuffix(3)).toBe('rd'));
+    it('4 → "th"', () => expect(getOrdinalSuffix(4)).toBe('th'));
+    it('7 → "th"', () => expect(getOrdinalSuffix(7)).toBe('th'));
+    it('10 → "th"', () => expect(getOrdinalSuffix(10)).toBe('th'));
+  });
+
+  describe('teen exceptions (11–13 → "th")', () => {
+    it('11 → "th"', () => expect(getOrdinalSuffix(11)).toBe('th'));
+    it('12 → "th"', () => expect(getOrdinalSuffix(12)).toBe('th'));
+    it('13 → "th"', () => expect(getOrdinalSuffix(13)).toBe('th'));
+  });
+
+  describe('tens + 1/2/3 override', () => {
+    it('21 → "st"', () => expect(getOrdinalSuffix(21)).toBe('st'));
+    it('22 → "nd"', () => expect(getOrdinalSuffix(22)).toBe('nd'));
+    it('23 → "rd"', () => expect(getOrdinalSuffix(23)).toBe('rd'));
+    it('31 → "st"', () => expect(getOrdinalSuffix(31)).toBe('st'));
+  });
+
+  describe('hundreds — teen exception applies', () => {
+    it('101 → "st"', () => expect(getOrdinalSuffix(101)).toBe('st'));
+    it('111 → "th" (teen exception)', () =>
+      expect(getOrdinalSuffix(111)).toBe('th'));
+    it('112 → "th" (teen exception)', () =>
+      expect(getOrdinalSuffix(112)).toBe('th'));
+    it('113 → "th" (teen exception)', () =>
+      expect(getOrdinalSuffix(113)).toBe('th'));
+    it('121 → "st"', () => expect(getOrdinalSuffix(121)).toBe('st'));
+  });
+
+  describe('error handling', () => {
+    it('throws for 0', () => expect(() => getOrdinalSuffix(0)).toThrow());
+    it('throws for negative number', () =>
+      expect(() => getOrdinalSuffix(-1)).toThrow());
+    it('throws for non-integer (float)', () =>
+      expect(() => getOrdinalSuffix(1.5)).toThrow());
+    it('error message mentions the invalid value', () =>
+      expect(() => getOrdinalSuffix(0)).toThrow('0'));
+  });
+});

--- a/packages/i18nify-js/src/modules/dateTime/__tests__/getPrimaryTimezone.test.ts
+++ b/packages/i18nify-js/src/modules/dateTime/__tests__/getPrimaryTimezone.test.ts
@@ -1,0 +1,73 @@
+import getPrimaryTimezone from '../getPrimaryTimezone';
+
+const mockMetadata = {
+  metadata_information: {
+    IN: { timezone_of_capital: 'Asia/Kolkata' },
+    US: { timezone_of_capital: 'America/New_York' },
+    RU: { timezone_of_capital: 'Europe/Moscow' },
+    AU: { timezone_of_capital: 'Australia/Sydney' },
+    GB: { timezone_of_capital: 'Europe/London' },
+    DE: { timezone_of_capital: 'Europe/Berlin' },
+  },
+};
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(mockMetadata),
+  } as unknown as Response);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('getPrimaryTimezone', () => {
+  it('returns primary timezone for single-tz country (IN)', async () => {
+    await expect(getPrimaryTimezone('IN')).resolves.toBe('Asia/Kolkata');
+  });
+
+  it('returns capital timezone for multi-tz country (US)', async () => {
+    await expect(getPrimaryTimezone('US')).resolves.toBe('America/New_York');
+  });
+
+  it('returns capital timezone for multi-tz country (RU)', async () => {
+    await expect(getPrimaryTimezone('RU')).resolves.toBe('Europe/Moscow');
+  });
+
+  it('is case-insensitive (lowercase input)', async () => {
+    await expect(getPrimaryTimezone('in')).resolves.toBe('Asia/Kolkata');
+  });
+
+  it('is case-insensitive (mixed case input)', async () => {
+    await expect(getPrimaryTimezone('Au')).resolves.toBe('Australia/Sydney');
+  });
+
+  it('rejects for empty string', async () => {
+    await expect(getPrimaryTimezone('')).rejects.toThrow();
+  });
+
+  it('rejects for whitespace-only input', async () => {
+    await expect(getPrimaryTimezone('  ')).rejects.toThrow();
+  });
+
+  it('rejects for unknown country code', async () => {
+    await expect(getPrimaryTimezone('ZZ')).rejects.toThrow(/ZZ/);
+  });
+
+  it('rejects when fetch fails', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(
+      new Error('network error'),
+    );
+    await expect(getPrimaryTimezone('IN')).rejects.toThrow(/network error/);
+  });
+
+  it('rejects when response is not ok', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as unknown as Response);
+    await expect(getPrimaryTimezone('IN')).rejects.toThrow(/404/);
+  });
+});

--- a/packages/i18nify-js/src/modules/dateTime/__tests__/getTimeZoneByCountry.test.ts
+++ b/packages/i18nify-js/src/modules/dateTime/__tests__/getTimeZoneByCountry.test.ts
@@ -1,0 +1,153 @@
+import getTimeZoneByCountry from '../getTimeZoneByCountry';
+
+const METADATA_RESPONSE = {
+  metadata_information: {
+    IN: {
+      timezones: {
+        'Asia/Kolkata': { utc_offset: 'UTC +05:30' },
+      },
+    },
+    US: {
+      timezones: {
+        'America/New_York': { utc_offset: 'UTC -05:00' },
+        'America/Chicago': { utc_offset: 'UTC -06:00' },
+        'America/Denver': { utc_offset: 'UTC -07:00' },
+        'America/Los_Angeles': { utc_offset: 'UTC -08:00' },
+      },
+    },
+    AF: {
+      timezones: {
+        'Asia/Kabul': { utc_offset: 'UTC +04:30' },
+      },
+    },
+    // No timezones field
+    XX: {
+      country_name: 'Unknown',
+    },
+  },
+};
+
+const mockFetch = () =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(METADATA_RESPONSE),
+  } as Response);
+
+beforeEach(() => {
+  global.fetch = jest.fn(mockFetch);
+});
+
+describe('getTimeZoneByCountry', () => {
+  describe('valid country codes', () => {
+    it('returns a single timezone for a single-timezone country', async () => {
+      const result = await getTimeZoneByCountry('IN');
+      expect(result).toEqual({ 'Asia/Kolkata': { utc_offset: 'UTC +05:30' } });
+    });
+
+    it('returns all timezones for a multi-timezone country', async () => {
+      const result = await getTimeZoneByCountry('US');
+      expect(Object.keys(result)).toHaveLength(4);
+      expect(result['America/New_York']).toEqual({ utc_offset: 'UTC -05:00' });
+      expect(result['America/Los_Angeles']).toEqual({
+        utc_offset: 'UTC -08:00',
+      });
+    });
+
+    it('is case-insensitive — lowercased code works', async () => {
+      const result = await getTimeZoneByCountry('in');
+      expect(result).toEqual({ 'Asia/Kolkata': { utc_offset: 'UTC +05:30' } });
+    });
+
+    it('trims whitespace from country code', async () => {
+      const result = await getTimeZoneByCountry('  IN  ');
+      expect(result).toEqual({ 'Asia/Kolkata': { utc_offset: 'UTC +05:30' } });
+    });
+
+    it('each timezone entry contains utc_offset', async () => {
+      const result = await getTimeZoneByCountry('US');
+      for (const entry of Object.values(result)) {
+        expect(entry).toHaveProperty('utc_offset');
+        expect(typeof entry.utc_offset).toBe('string');
+      }
+    });
+  });
+
+  describe('empty / blank input', () => {
+    it('rejects on empty string', async () => {
+      await expect(getTimeZoneByCountry('')).rejects.toThrow(
+        'getTimeZoneByCountry: country code must not be empty.',
+      );
+    });
+
+    it('rejects on whitespace-only string', async () => {
+      await expect(getTimeZoneByCountry('   ')).rejects.toThrow(
+        'getTimeZoneByCountry: country code must not be empty.',
+      );
+    });
+  });
+
+  describe('unknown country codes', () => {
+    it('rejects when country code is not in metadata', async () => {
+      await expect(getTimeZoneByCountry('ZZ')).rejects.toThrow(
+        'An error occurred while fetching timezone data for country "ZZ"',
+      );
+    });
+
+    it('rejects when country has no timezones field', async () => {
+      await expect(getTimeZoneByCountry('XX')).rejects.toThrow(
+        'An error occurred while fetching timezone data for country "XX"',
+      );
+    });
+  });
+
+  describe('network and API errors', () => {
+    it('rejects on network failure', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.reject(new Error('Network timeout')),
+      );
+      await expect(getTimeZoneByCountry('IN')).rejects.toThrow(
+        'An error occurred while fetching timezone data for country "IN". The error details are: Network timeout.',
+      );
+    });
+
+    it('rejects on non-ok HTTP response', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        } as Response),
+      );
+      await expect(getTimeZoneByCountry('IN')).rejects.toThrow(
+        'An error occurred while fetching timezone data for country "IN"',
+      );
+    });
+
+    it('rejects on HTTP 500 error', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+        } as Response),
+      );
+      await expect(getTimeZoneByCountry('IN')).rejects.toThrow(
+        'An error occurred while fetching timezone data for country "IN"',
+      );
+    });
+
+    it('rejects when metadata_information key is missing', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ invalid_key: {} }),
+        } as Response),
+      );
+      await expect(getTimeZoneByCountry('IN')).rejects.toThrow(
+        'An error occurred while fetching timezone data for country "IN"',
+      );
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/dateTime/__tests__/getTimezoneList.test.ts
+++ b/packages/i18nify-js/src/modules/dateTime/__tests__/getTimezoneList.test.ts
@@ -1,0 +1,178 @@
+import getTimezoneList from '../getTimezoneList';
+
+const METADATA_RESPONSE = {
+  metadata_information: {
+    IN: {
+      timezones: {
+        'Asia/Kolkata': { utc_offset: 'UTC +05:30' },
+      },
+    },
+    US: {
+      timezones: {
+        'America/New_York': { utc_offset: 'UTC -05:00' },
+        'America/Chicago': { utc_offset: 'UTC -06:00' },
+      },
+    },
+    // Countries that share a timezone
+    AG: {
+      timezones: {
+        'America/Port_of_Spain': { utc_offset: 'UTC -04:00' },
+      },
+    },
+    LC: {
+      timezones: {
+        'America/Port_of_Spain': { utc_offset: 'UTC -04:00' },
+      },
+    },
+    // Country with no timezones field
+    XX: {
+      country_name: 'Unknown',
+    },
+  },
+};
+
+const mockFetch = () =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(METADATA_RESPONSE),
+  } as Response);
+
+beforeEach(() => {
+  global.fetch = jest.fn(mockFetch);
+});
+
+describe('getTimezoneList', () => {
+  describe('returned structure', () => {
+    it('returns a non-empty map of timezone identifiers', async () => {
+      const result = await getTimezoneList();
+      expect(typeof result).toBe('object');
+      expect(Object.keys(result).length).toBeGreaterThan(0);
+    });
+
+    it('includes known IANA timezone keys', async () => {
+      const result = await getTimezoneList();
+      expect(result).toHaveProperty('Asia/Kolkata');
+      expect(result).toHaveProperty('America/New_York');
+    });
+
+    it('each entry has utc_offset and countries array', async () => {
+      const result = await getTimezoneList();
+      for (const entry of Object.values(result)) {
+        expect(typeof entry.utc_offset).toBe('string');
+        expect(Array.isArray(entry.countries)).toBe(true);
+      }
+    });
+
+    it('utc_offset value matches the source data', async () => {
+      const result = await getTimezoneList();
+      expect(result['Asia/Kolkata'].utc_offset).toBe('UTC +05:30');
+      expect(result['America/New_York'].utc_offset).toBe('UTC -05:00');
+    });
+
+    it('countries list for a single-country timezone contains that country', async () => {
+      const result = await getTimezoneList();
+      expect(result['Asia/Kolkata'].countries).toContain('IN');
+    });
+
+    it('countries list for US timezones contains US', async () => {
+      const result = await getTimezoneList();
+      expect(result['America/New_York'].countries).toContain('US');
+      expect(result['America/Chicago'].countries).toContain('US');
+    });
+  });
+
+  describe('shared timezones', () => {
+    it('aggregates multiple countries under a shared timezone', async () => {
+      const result = await getTimezoneList();
+      const entry = result['America/Port_of_Spain'];
+      expect(entry.countries).toContain('AG');
+      expect(entry.countries).toContain('LC');
+    });
+
+    it('does not duplicate a country code for the same timezone', async () => {
+      const result = await getTimezoneList();
+      const entry = result['America/Port_of_Spain'];
+      const unique = new Set(entry.countries);
+      expect(unique.size).toBe(entry.countries.length);
+    });
+  });
+
+  describe('countries without timezones', () => {
+    it('skips countries that have no timezones field', async () => {
+      const result = await getTimezoneList();
+      // XX has no timezones — it should not appear in any entry's countries list
+      for (const entry of Object.values(result)) {
+        expect(entry.countries).not.toContain('XX');
+      }
+    });
+  });
+
+  describe('empty metadata', () => {
+    it('returns an empty object when no country has timezones', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              metadata_information: {
+                XX: { country_name: 'Unknown' },
+              },
+            }),
+        } as Response),
+      );
+      const result = await getTimezoneList();
+      expect(result).toEqual({});
+    });
+
+    it('returns an empty object when metadata_information is missing', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ other_key: {} }),
+        } as Response),
+      );
+      const result = await getTimezoneList();
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('network and API errors', () => {
+    it('rejects on network failure', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.reject(new Error('Network timeout')),
+      );
+      await expect(getTimezoneList()).rejects.toThrow(
+        'An error occurred while fetching the timezone list. The error details are: Network timeout.',
+      );
+    });
+
+    it('rejects on non-ok HTTP response', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        } as Response),
+      );
+      await expect(getTimezoneList()).rejects.toThrow(
+        'An error occurred while fetching the timezone list',
+      );
+    });
+
+    it('rejects on HTTP 500 error', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+        } as Response),
+      );
+      await expect(getTimezoneList()).rejects.toThrow(
+        'An error occurred while fetching the timezone list',
+      );
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/dateTime/__tests__/parseFlexibleDate.test.ts
+++ b/packages/i18nify-js/src/modules/dateTime/__tests__/parseFlexibleDate.test.ts
@@ -1,0 +1,115 @@
+import parseFlexibleDate from '../parseFlexibleDate';
+
+describe('parseFlexibleDate', () => {
+  describe('Date object input', () => {
+    it('accepts a Date object and returns structured result', () => {
+      const d = new Date(2024, 0, 15, 10, 30, 45); // Jan 15 2024 10:30:45 local
+      const result = parseFlexibleDate(d);
+      expect(result.date).toBeInstanceOf(Date);
+      expect(result.year).toBe(2024);
+      expect(result.month).toBe(1);
+      expect(result.day).toBe(15);
+      expect(result.hour).toBe(10);
+      expect(result.minute).toBe(30);
+      expect(result.second).toBe(45);
+    });
+
+    it('timestamp matches the input Date.getTime()', () => {
+      const d = new Date(2024, 5, 20);
+      const result = parseFlexibleDate(d);
+      expect(result.timestamp).toBe(d.getTime());
+    });
+  });
+
+  describe('numeric (Unix timestamp ms) input', () => {
+    it('accepts a Unix timestamp in milliseconds', () => {
+      const ts = new Date(2021, 0, 1).getTime();
+      const result = parseFlexibleDate(ts);
+      expect(result.year).toBe(2021);
+      expect(result.month).toBe(1);
+      expect(result.day).toBe(1);
+    });
+
+    it('timestamp field equals the input number', () => {
+      const ts = 1609459200000;
+      const result = parseFlexibleDate(ts);
+      expect(result.timestamp).toBe(ts);
+    });
+  });
+
+  describe('ISO 8601 string input', () => {
+    it('parses YYYY-MM-DD string', () => {
+      const result = parseFlexibleDate('2024-01-15');
+      expect(result.year).toBe(2024);
+      expect(result.month).toBe(1);
+      expect(result.day).toBe(15);
+    });
+  });
+
+  describe('alternative date format strings', () => {
+    it('parses DD/MM/YYYY string', () => {
+      const result = parseFlexibleDate('15/01/2024');
+      expect(result.year).toBe(2024);
+      expect(result.month).toBe(1);
+      expect(result.day).toBe(15);
+    });
+
+    it('parses YYYY/MM/DD string', () => {
+      const result = parseFlexibleDate('2024/01/15');
+      expect(result.year).toBe(2024);
+      expect(result.month).toBe(1);
+      expect(result.day).toBe(15);
+    });
+  });
+
+  describe('returned structure', () => {
+    it('always returns all required fields', () => {
+      const result = parseFlexibleDate(new Date(2024, 2, 10));
+      expect(result).toHaveProperty('date');
+      expect(result).toHaveProperty('year');
+      expect(result).toHaveProperty('month');
+      expect(result).toHaveProperty('day');
+      expect(result).toHaveProperty('hour');
+      expect(result).toHaveProperty('minute');
+      expect(result).toHaveProperty('second');
+      expect(result).toHaveProperty('timestamp');
+    });
+
+    it('month is 1-indexed (1–12)', () => {
+      const result = parseFlexibleDate(new Date(2024, 11, 1)); // December
+      expect(result.month).toBe(12);
+    });
+
+    it('date field is a Date instance', () => {
+      const result = parseFlexibleDate(new Date());
+      expect(result.date).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws for null input', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => parseFlexibleDate(null as any)).toThrow(
+        'parseFlexibleDate: invalid input',
+      );
+    });
+
+    it('throws for undefined input', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => parseFlexibleDate(undefined as any)).toThrow(
+        'parseFlexibleDate: invalid input',
+      );
+    });
+
+    it('throws for empty string', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => parseFlexibleDate('' as any)).toThrow(
+        'parseFlexibleDate: invalid input',
+      );
+    });
+
+    it('throws for an unrecognised date string', () => {
+      expect(() => parseFlexibleDate('not-a-date')).toThrow();
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/dateTime/__tests__/timezoneToCountry.test.ts
+++ b/packages/i18nify-js/src/modules/dateTime/__tests__/timezoneToCountry.test.ts
@@ -1,0 +1,159 @@
+import timezoneToCountry from '../timezoneToCountry';
+
+const METADATA_RESPONSE = {
+  metadata_information: {
+    IN: {
+      timezones: {
+        'Asia/Kolkata': { utc_offset: 'UTC +05:30' },
+      },
+    },
+    US: {
+      timezones: {
+        'America/New_York': { utc_offset: 'UTC -05:00' },
+        'America/Chicago': { utc_offset: 'UTC -06:00' },
+        'America/Denver': { utc_offset: 'UTC -07:00' },
+        'America/Los_Angeles': { utc_offset: 'UTC -08:00' },
+      },
+    },
+    // Countries sharing a timezone
+    AG: {
+      timezones: {
+        'America/Port_of_Spain': { utc_offset: 'UTC -04:00' },
+      },
+    },
+    LC: {
+      timezones: {
+        'America/Port_of_Spain': { utc_offset: 'UTC -04:00' },
+      },
+    },
+    // Country with no timezones field
+    XX: { country_name: 'Unknown' },
+  },
+};
+
+const mockFetch = () =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(METADATA_RESPONSE),
+  } as Response);
+
+beforeEach(() => {
+  global.fetch = jest.fn(mockFetch);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('timezoneToCountry', () => {
+  describe('single-country timezones', () => {
+    it('returns ["IN"] for Asia/Kolkata', async () => {
+      const result = await timezoneToCountry('Asia/Kolkata');
+      expect(result).toEqual(['IN']);
+    });
+
+    it('returns an array with one element for a unique timezone', async () => {
+      const result = await timezoneToCountry('Asia/Kolkata');
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('multi-country timezones', () => {
+    it('returns all countries that share a timezone', async () => {
+      const result = await timezoneToCountry('America/Port_of_Spain');
+      expect(result).toContain('AG');
+      expect(result).toContain('LC');
+    });
+
+    it('does not include unrelated countries', async () => {
+      const result = await timezoneToCountry('America/Port_of_Spain');
+      expect(result).not.toContain('IN');
+      expect(result).not.toContain('US');
+    });
+  });
+
+  describe('multi-timezone country', () => {
+    it('includes US for America/New_York', async () => {
+      const result = await timezoneToCountry('America/New_York');
+      expect(result).toContain('US');
+    });
+
+    it('includes US for America/Chicago', async () => {
+      const result = await timezoneToCountry('America/Chicago');
+      expect(result).toContain('US');
+    });
+  });
+
+  describe('whitespace handling', () => {
+    it('trims leading/trailing whitespace from timezone', async () => {
+      const result = await timezoneToCountry('  Asia/Kolkata  ');
+      expect(result).toContain('IN');
+    });
+  });
+
+  describe('empty / blank input', () => {
+    it('rejects on empty string', async () => {
+      await expect(timezoneToCountry('')).rejects.toThrow(
+        'timezoneToCountry: timezone must not be empty.',
+      );
+    });
+
+    it('rejects on whitespace-only string', async () => {
+      await expect(timezoneToCountry('   ')).rejects.toThrow(
+        'timezoneToCountry: timezone must not be empty.',
+      );
+    });
+  });
+
+  describe('unknown timezone', () => {
+    it('rejects when timezone is not in any country', async () => {
+      await expect(timezoneToCountry('Pacific/Fake')).rejects.toThrow(
+        'An error occurred while fetching country codes for timezone "Pacific/Fake"',
+      );
+    });
+
+    it('error message includes the timezone identifier', async () => {
+      await expect(timezoneToCountry('NotReal/Zone')).rejects.toThrow(
+        '"NotReal/Zone"',
+      );
+    });
+  });
+
+  describe('network and API errors', () => {
+    it('rejects on network failure', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.reject(new Error('Network timeout')),
+      );
+      await expect(timezoneToCountry('Asia/Kolkata')).rejects.toThrow(
+        'An error occurred while fetching country codes for timezone "Asia/Kolkata". The error details are: Network timeout.',
+      );
+    });
+
+    it('rejects on non-ok HTTP response', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        } as Response),
+      );
+      await expect(timezoneToCountry('Asia/Kolkata')).rejects.toThrow(
+        'An error occurred while fetching country codes for timezone "Asia/Kolkata"',
+      );
+    });
+
+    it('rejects on HTTP 500', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+        } as Response),
+      );
+      await expect(timezoneToCountry('Asia/Kolkata')).rejects.toThrow(
+        'An error occurred while fetching country codes for timezone "Asia/Kolkata"',
+      );
+    });
+  });
+});

--- a/packages/i18nify-js/src/modules/dateTime/formatFromUnix.ts
+++ b/packages/i18nify-js/src/modules/dateTime/formatFromUnix.ts
@@ -1,0 +1,56 @@
+import { DateFormatter } from '@internationalized/date';
+
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { getLocale } from '../.internal/utils';
+import { DateTimeFormatOptions, Locale } from './types';
+
+const DEFAULT_FORMAT_OPTIONS: DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+};
+
+/**
+ * Converts a Unix timestamp (seconds since epoch) to a timezone-aware
+ * formatted datetime string using the provided locale and Intl options.
+ *
+ * @param {number} unixTimestamp - Seconds since the Unix epoch (integer or float).
+ * @param options - Config object.
+ * @param {string}  [options.timezone]    - IANA timezone name (e.g. "America/New_York").
+ *                                          When omitted, the runtime's local timezone is used.
+ * @param {string}  [options.locale]      - BCP 47 locale tag. Falls back to state/env locale.
+ * @param {Intl.DateTimeFormatOptions} [options.intlOptions] - Overrides for individual format fields.
+ * @returns {string} Formatted datetime string.
+ */
+const formatFromUnix = (
+  unixTimestamp: number,
+  options: {
+    timezone?: string;
+    locale?: Locale;
+    intlOptions?: Intl.DateTimeFormatOptions;
+  } = {},
+): string => {
+  if (!Number.isFinite(unixTimestamp)) {
+    throw new Error(
+      `Invalid Unix timestamp: received ${String(unixTimestamp)}. Expected a finite number representing seconds since the Unix epoch.`,
+    );
+  }
+
+  const { timezone, intlOptions } = options;
+  const resolvedLocale = getLocale(options);
+
+  const date = new Date(unixTimestamp * 1000);
+
+  const formatOptions: DateTimeFormatOptions = {
+    ...(intlOptions ?? DEFAULT_FORMAT_OPTIONS),
+    ...(timezone ? { timeZone: timezone } : {}),
+  };
+
+  const formatter = new DateFormatter(resolvedLocale, formatOptions);
+  return formatter.format(date);
+};
+
+export default withErrorBoundary<typeof formatFromUnix>(formatFromUnix);

--- a/packages/i18nify-js/src/modules/dateTime/getFinancialYear.ts
+++ b/packages/i18nify-js/src/modules/dateTime/getFinancialYear.ts
@@ -1,0 +1,82 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { DateInput } from './types';
+import { convertToStandardDate } from './utils';
+
+export type FYLabelFormat = 'short' | 'long' | 'fy';
+
+export interface GetFinancialYearOptions {
+  labelFormat?: FYLabelFormat;
+}
+
+interface FYConfig {
+  startMonth: number;
+  labelFormat: FYLabelFormat;
+}
+
+// FY start month (1-indexed) and default label format per country.
+const FY_CONFIG: Record<string, FYConfig> = {
+  // April 1 → March 31  → "2024-25"
+  IN: { startMonth: 4, labelFormat: 'short' },
+  JP: { startMonth: 4, labelFormat: 'short' },
+  GB: { startMonth: 4, labelFormat: 'short' },
+  CA: { startMonth: 4, labelFormat: 'short' },
+  NZ: { startMonth: 4, labelFormat: 'short' },
+  SG: { startMonth: 4, labelFormat: 'short' },
+  ZA: { startMonth: 4, labelFormat: 'short' },
+  // July 1 → June 30  → "2024-25"
+  AU: { startMonth: 7, labelFormat: 'short' },
+  BD: { startMonth: 7, labelFormat: 'short' },
+  PK: { startMonth: 7, labelFormat: 'short' },
+  // October 1 → September 30  → "FY2025"
+  US: { startMonth: 10, labelFormat: 'fy' },
+};
+
+const SUPPORTED_COUNTRIES = Object.keys(FY_CONFIG).join(', ');
+
+const buildLabel = (
+  fyStartYear: number,
+  fyEndYear: number,
+  format: FYLabelFormat,
+): string => {
+  switch (format) {
+    case 'short':
+      return `${fyStartYear}-${String(fyEndYear).slice(-2)}`;
+    case 'long':
+      return `${fyStartYear}-${fyEndYear}`;
+    case 'fy':
+      return `FY${fyEndYear}`;
+  }
+};
+
+const getFinancialYear = (
+  date: DateInput,
+  countryCode: string,
+  options: GetFinancialYearOptions = {},
+): string => {
+  if (date === null || date === undefined || date === '')
+    throw new Error(
+      `Parameter 'date' is invalid! The received value was: ${date}.`,
+    );
+  if (!countryCode)
+    throw new Error(
+      `Parameter 'countryCode' is invalid! The received value was: ${countryCode}.`,
+    );
+
+  const config = FY_CONFIG[countryCode.toUpperCase()];
+  if (!config)
+    throw new Error(
+      `Country code "${countryCode}" is not supported for financial year calculation. Supported countries: ${SUPPORTED_COUNTRIES}.`,
+    );
+
+  const d = convertToStandardDate(date);
+  const year = d.getFullYear();
+  const month = d.getMonth() + 1; // convert to 1-indexed
+
+  const fyStartYear = month >= config.startMonth ? year : year - 1;
+  const fyEndYear = fyStartYear + 1;
+  const labelFormat = options.labelFormat ?? config.labelFormat;
+
+  return buildLabel(fyStartYear, fyEndYear, labelFormat);
+};
+
+export default withErrorBoundary<typeof getFinancialYear>(getFinancialYear);

--- a/packages/i18nify-js/src/modules/dateTime/getOrdinalSuffix.ts
+++ b/packages/i18nify-js/src/modules/dateTime/getOrdinalSuffix.ts
@@ -1,0 +1,24 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+
+const getOrdinalSuffix = (n: number): string => {
+  if (!Number.isInteger(n) || n < 1)
+    throw new Error(
+      `Parameter 'n' is invalid! Expected a positive integer, received: ${n}.`,
+    );
+
+  const lastTwo = n % 100;
+  if (lastTwo >= 11 && lastTwo <= 13) return 'th';
+
+  switch (n % 10) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+};
+
+export default withErrorBoundary<typeof getOrdinalSuffix>(getOrdinalSuffix);

--- a/packages/i18nify-js/src/modules/dateTime/getPrimaryTimezone.ts
+++ b/packages/i18nify-js/src/modules/dateTime/getPrimaryTimezone.ts
@@ -1,0 +1,61 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { I18NIFY_DATA_SOURCE } from '../shared';
+
+/**
+ * Returns the primary IANA timezone identifier for a given country code.
+ *
+ * For single-timezone countries it is the only timezone. For multi-timezone
+ * countries (e.g. "US", "RU", "AU") it is the capital city's timezone, sourced
+ * from the timezone_of_capital field in the i18nify country metadata.
+ *
+ * @param {string} countryCode - ISO 3166-1 alpha-2 country code (case-insensitive), e.g. "IN".
+ * @returns {Promise<string>} A promise resolving to the primary IANA timezone identifier.
+ *
+ * @example
+ * getPrimaryTimezone('IN');  // → "Asia/Kolkata"
+ * getPrimaryTimezone('US');  // → "America/New_York"
+ * getPrimaryTimezone('RU');  // → "Europe/Moscow"
+ */
+const getPrimaryTimezone = (countryCode: string): Promise<string> => {
+  if (!countryCode || !countryCode.trim()) {
+    return Promise.reject(
+      new Error('getPrimaryTimezone: country code must not be empty.'),
+    );
+  }
+
+  const normalizedCode = countryCode.trim().toUpperCase();
+
+  return fetch(`${I18NIFY_DATA_SOURCE}/country/metadata/data.json`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      }
+      return res.json();
+    })
+    .then((res) => {
+      const countryMeta = res.metadata_information?.[normalizedCode];
+
+      if (!countryMeta) {
+        throw new Error(
+          `Country code "${normalizedCode}" not found in metadata.`,
+        );
+      }
+
+      const tz: string = countryMeta.timezone_of_capital ?? '';
+
+      if (!tz) {
+        throw new Error(
+          `No primary timezone found for country code "${normalizedCode}".`,
+        );
+      }
+
+      return tz;
+    })
+    .catch((err) => {
+      throw new Error(
+        `An error occurred while fetching primary timezone for country "${countryCode}". The error details are: ${err.message}.`,
+      );
+    });
+};
+
+export default withErrorBoundary<typeof getPrimaryTimezone>(getPrimaryTimezone);

--- a/packages/i18nify-js/src/modules/dateTime/getTimeZoneByCountry.ts
+++ b/packages/i18nify-js/src/modules/dateTime/getTimeZoneByCountry.ts
@@ -1,0 +1,77 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { I18NIFY_DATA_SOURCE } from '../shared';
+import { TimezoneDetail } from './types';
+
+/**
+ * Retrieves timezone identifiers and their UTC offsets for a given country.
+ *
+ * This function makes a network request to the central i18nify-data source and
+ * returns a promise resolving to a map of IANA timezone identifiers to their
+ * UTC offset strings.
+ *
+ * Countries that observe multiple timezones (e.g., "US", "RU", "AU") return
+ * the full set. The returned structure is identical to the Go
+ * GetTimeZoneByCountry implementation.
+ *
+ * @param {string} countryCode - ISO 3166-1 alpha-2 country code (case-insensitive), e.g. "IN", "US".
+ * @returns {Promise<Record<string, TimezoneDetail>>} A promise resolving to a
+ *   map from IANA timezone identifier to timezone detail.
+ *
+ * @example
+ * // Single-timezone country
+ * getTimeZoneByCountry('IN');
+ * // → { "Asia/Kolkata": { utc_offset: "UTC +05:30" } }
+ *
+ * @example
+ * // Multi-timezone country
+ * getTimeZoneByCountry('US');
+ * // → { "America/New_York": { utc_offset: "UTC -05:00" }, "America/Chicago": { ... }, ... }
+ */
+const getTimeZoneByCountry = (
+  countryCode: string,
+): Promise<Record<string, TimezoneDetail>> => {
+  if (!countryCode || !countryCode.trim()) {
+    return Promise.reject(
+      new Error('getTimeZoneByCountry: country code must not be empty.'),
+    );
+  }
+
+  const normalizedCode = countryCode.trim().toUpperCase();
+
+  return fetch(`${I18NIFY_DATA_SOURCE}/country/metadata/data.json`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      }
+      return res.json();
+    })
+    .then((res) => {
+      const countryMeta = res.metadata_information?.[normalizedCode];
+
+      if (!countryMeta) {
+        throw new Error(
+          `Country code "${normalizedCode}" not found in metadata.`,
+        );
+      }
+
+      const timezones: Record<string, TimezoneDetail> =
+        countryMeta.timezones ?? {};
+
+      if (Object.keys(timezones).length === 0) {
+        throw new Error(
+          `No timezone data found for country code "${normalizedCode}".`,
+        );
+      }
+
+      return timezones;
+    })
+    .catch((err) => {
+      throw new Error(
+        `An error occurred while fetching timezone data for country "${countryCode}". The error details are: ${err.message}.`,
+      );
+    });
+};
+
+export default withErrorBoundary<typeof getTimeZoneByCountry>(
+  getTimeZoneByCountry,
+);

--- a/packages/i18nify-js/src/modules/dateTime/getTimezoneList.ts
+++ b/packages/i18nify-js/src/modules/dateTime/getTimezoneList.ts
@@ -1,0 +1,76 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { I18NIFY_DATA_SOURCE } from '../shared';
+import { TimezoneListEntry } from './types';
+
+/**
+ * Retrieves the complete list of all IANA timezone identifiers across every
+ * country, aggregated with their UTC offset and the list of country codes
+ * that observe each timezone.
+ *
+ * This function makes a single network request to the central i18nify-data
+ * source and builds an aggregated index from the country metadata. Countries
+ * that share a timezone (e.g., multiple Caribbean nations sharing
+ * "America/Port_of_Spain") are all listed under that timezone's entry.
+ *
+ * The returned structure mirrors the data model used by the Go
+ * GetTimeZoneByCountry implementation extended with cross-country aggregation.
+ *
+ * @returns {Promise<Record<string, TimezoneListEntry>>} A promise resolving to
+ *   a map from IANA timezone identifier to its detail and observing countries.
+ *
+ * @example
+ * const list = await getTimezoneList();
+ * list['Asia/Kolkata'];
+ * // → { utc_offset: "UTC +05:30", countries: ["IN"] }
+ *
+ * list['America/New_York'];
+ * // → { utc_offset: "UTC -05:00", countries: ["US", "CA", ...] }
+ */
+const getTimezoneList = (): Promise<Record<string, TimezoneListEntry>> => {
+  return fetch(`${I18NIFY_DATA_SOURCE}/country/metadata/data.json`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      }
+      return res.json();
+    })
+    .then((res) => {
+      const metadataInfo: Record<
+        string,
+        { timezones?: Record<string, { utc_offset: string }> }
+      > = res.metadata_information ?? {};
+
+      const result: Record<string, TimezoneListEntry> = {};
+
+      for (const countryCode of Object.keys(metadataInfo)) {
+        const countryData = metadataInfo[countryCode];
+
+        if (!countryData.timezones) continue;
+
+        const timezones: Record<string, { utc_offset: string }> =
+          countryData.timezones;
+        Object.keys(timezones).forEach((tzIdentifier) => {
+          const tzInfo = timezones[tzIdentifier];
+          if (!result[tzIdentifier]) {
+            result[tzIdentifier] = {
+              utc_offset: tzInfo.utc_offset,
+              countries: [],
+            };
+          }
+
+          if (result[tzIdentifier].countries.indexOf(countryCode) === -1) {
+            result[tzIdentifier].countries.push(countryCode);
+          }
+        });
+      }
+
+      return result;
+    })
+    .catch((err) => {
+      throw new Error(
+        `An error occurred while fetching the timezone list. The error details are: ${err.message}.`,
+      );
+    });
+};
+
+export default withErrorBoundary<typeof getTimezoneList>(getTimezoneList);

--- a/packages/i18nify-js/src/modules/dateTime/index.ts
+++ b/packages/i18nify-js/src/modules/dateTime/index.ts
@@ -8,6 +8,14 @@ export { default as formatDateTime } from './formatDateTime';
 export { default as getRelativeTime } from './getRelativeTime';
 export { default as getWeekdays } from './getWeekdays';
 export { default as parseDateTime } from './parseDateTime';
+export { default as formatFromUnix } from './formatFromUnix';
+export { default as getFinancialYear } from './getFinancialYear';
+export { default as getOrdinalSuffix } from './getOrdinalSuffix';
+export { default as getPrimaryTimezone } from './getPrimaryTimezone';
+export { default as getTimeZoneByCountry } from './getTimeZoneByCountry';
+export { default as getTimezoneList } from './getTimezoneList';
+export { default as timezoneToCountry } from './timezoneToCountry';
+export { default as parseFlexibleDate } from './parseFlexibleDate';
 
 // For additional information, refer to the documentation: https://react-spectrum.adobe.com/internationalized/date/index.html
 /**

--- a/packages/i18nify-js/src/modules/dateTime/parseFlexibleDate.ts
+++ b/packages/i18nify-js/src/modules/dateTime/parseFlexibleDate.ts
@@ -1,0 +1,55 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { DateInput } from './types';
+import { convertToStandardDate } from './utils';
+
+export interface ParsedFlexibleDate {
+  date: Date;
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  timestamp: number;
+}
+
+/**
+ * Parses a date in any supported format and returns a structured result.
+ *
+ * Accepts:
+ * - Date objects (returned as-is)
+ * - Unix timestamps (milliseconds since epoch as a number)
+ * - Date strings in multiple formats: ISO 8601, YYYY/MM/DD, DD/MM/YYYY,
+ *   MM/DD/YYYY, DD-MM-YYYY, YYYY.MM.DD, and their datetime variants.
+ *
+ * @param {DateInput} input - A Date object, Unix timestamp (ms), or date string.
+ * @returns {ParsedFlexibleDate} Structured date components plus the Date and timestamp.
+ */
+const parseFlexibleDate = (input: DateInput): ParsedFlexibleDate => {
+  if (input === null || input === undefined || input === '') {
+    throw new Error(
+      `parseFlexibleDate: invalid input — received: ${String(input)}.`,
+    );
+  }
+
+  const date = convertToStandardDate(input);
+
+  if (isNaN(date.getTime())) {
+    throw new Error(
+      `parseFlexibleDate: could not parse "${String(input)}" as a valid date.`,
+    );
+  }
+
+  return {
+    date,
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate(),
+    hour: date.getHours(),
+    minute: date.getMinutes(),
+    second: date.getSeconds(),
+    timestamp: date.getTime(),
+  };
+};
+
+export default withErrorBoundary<typeof parseFlexibleDate>(parseFlexibleDate);

--- a/packages/i18nify-js/src/modules/dateTime/timezoneToCountry.ts
+++ b/packages/i18nify-js/src/modules/dateTime/timezoneToCountry.ts
@@ -1,0 +1,65 @@
+import { withErrorBoundary } from '../../common/errorBoundary';
+import { I18NIFY_DATA_SOURCE } from '../shared';
+
+/**
+ * Reverse timezone lookup — given an IANA timezone identifier, returns the
+ * ISO 3166-1 alpha-2 country codes that observe it.
+ *
+ * For single-country timezones (e.g. "Asia/Kolkata") the result is a
+ * single-element array (["IN"]). For shared timezones (e.g. "America/New_York")
+ * the result may contain multiple country codes.
+ *
+ * @param {string} timezone - IANA timezone identifier (e.g. "Asia/Kolkata").
+ * @returns {Promise<string[]>} Country codes that observe the timezone.
+ *
+ * @example
+ * timezoneToCountry('Asia/Kolkata');      // → ["IN"]
+ * timezoneToCountry('America/New_York');  // → ["US", ...]
+ */
+const timezoneToCountry = (timezone: string): Promise<string[]> => {
+  if (!timezone || !timezone.trim()) {
+    return Promise.reject(
+      new Error('timezoneToCountry: timezone must not be empty.'),
+    );
+  }
+
+  const normalizedTz = timezone.trim();
+
+  return fetch(`${I18NIFY_DATA_SOURCE}/country/metadata/data.json`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      }
+      return res.json();
+    })
+    .then((res) => {
+      const metadataInfo: Record<
+        string,
+        { timezones?: Record<string, unknown> }
+      > = res.metadata_information ?? {};
+
+      const countries: string[] = [];
+
+      for (const countryCode of Object.keys(metadataInfo)) {
+        const timezones = metadataInfo[countryCode]?.timezones ?? {};
+        if (normalizedTz in timezones) {
+          countries.push(countryCode);
+        }
+      }
+
+      if (countries.length === 0) {
+        throw new Error(
+          `Timezone "${normalizedTz}" not found in any country metadata.`,
+        );
+      }
+
+      return countries;
+    })
+    .catch((err) => {
+      throw new Error(
+        `An error occurred while fetching country codes for timezone "${timezone}". The error details are: ${err.message}.`,
+      );
+    });
+};
+
+export default withErrorBoundary<typeof timezoneToCountry>(timezoneToCountry);


### PR DESCRIPTION
## Summary
- Add Go implementations for all 9 datetime module functions: `FormatDateTime`, `FormatFromUnix`, `GetRelativeTime`, `GetWeekdays`, `GetTimeZoneByCountry`, `GetTimezoneList`, `GetPrimaryTimezone`, `GetFinancialYear`, `GetOrdinalSuffix`
- Mirrors the i18nify-js `dateTime` module functionality in Go
- All functions follow existing i18nify-go conventions (package `datetime`, error returns, typed structs)

## Files added (10)
- `packages/i18nify-go/modules/datetime/datetime.go` — package doc + shared types (`TimeZoneInfo`, `TimezoneListEntry`)
- `packages/i18nify-go/modules/datetime/format_date_time.go`
- `packages/i18nify-go/modules/datetime/format_from_unix.go`
- `packages/i18nify-go/modules/datetime/get_financial_year.go`
- `packages/i18nify-go/modules/datetime/get_ordinal_suffix.go`
- `packages/i18nify-go/modules/datetime/get_primary_timezone.go`
- `packages/i18nify-go/modules/datetime/get_relative_time.go`
- `packages/i18nify-go/modules/datetime/get_timezone_by_country.go`
- `packages/i18nify-go/modules/datetime/get_timezone_list.go`
- `packages/i18nify-go/modules/datetime/get_weekdays.go`

## Test plan
- [ ] `go build ./packages/i18nify-go/modules/datetime/...`
- [ ] `go vet ./packages/i18nify-go/modules/datetime/...`
- [ ] Verify each function returns expected output for a known input

🤖 Generated with [Claude Code](https://claude.com/claude-code)