### PR TITLE
chore(ci): make Go package discovery fully dynamic

### DIFF
--- a/.github/scripts/go/discover-packages.sh
+++ b/.github/scripts/go/discover-packages.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+# Dynamic Package Discovery for i18nify-data Go packages
+#
+# Discovers valid Go-generatable packages by scanning i18nify-data/ for directories
+# that contain a proto/ subdirectory with at least one .proto file.
+#
+# Modes:
+#   --all              List all valid packages (for workflow_dispatch "all")
+#   --changed <base>   List only packages whose data files changed vs <base> ref
+#   --validate <csv>   Validate a comma-separated list of package names; outputs
+#                      only those that are actually valid packages
+#
+# Output: JSON array of package paths relative to i18nify-data/
+#         e.g. ["currency","country/subdivisions","bankcodes"]
+#
+# A package is considered valid when:
+#   i18nify-data/<pkg>/proto/*.proto exists
+#
+# Usage:
+#   ./discover-packages.sh --all
+#   ./discover-packages.sh --changed origin/master
+#   ./discover-packages.sh --changed HEAD~1
+#   ./discover-packages.sh --validate "currency, bankcodes, country/subdivisions"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+I18NIFY_DATA_DIR="$PROJECT_ROOT/i18nify-data"
+
+# --- Helpers ---
+
+# Returns all valid package paths (relative to i18nify-data/).
+# A valid package has at least one .proto file under <pkg>/proto/.
+discover_all_packages() {
+    local packages=()
+    while IFS= read -r proto_file; do
+        # proto_file is like: /abs/path/i18nify-data/currency/proto/currency.proto
+        # We want: currency
+        local proto_dir
+        proto_dir="$(dirname "$proto_file")"          # .../currency/proto
+        local pkg_abs_dir
+        pkg_abs_dir="$(dirname "$proto_dir")"         # .../currency
+        local pkg_rel
+        pkg_rel="${pkg_abs_dir#"$I18NIFY_DATA_DIR/"}" # currency
+
+        # Deduplicate (multiple .proto files in same dir)
+        local already_added=false
+        for p in "${packages[@]:-}"; do
+            if [ "$p" = "$pkg_rel" ]; then
+                already_added=true
+                break
+            fi
+        done
+        if [ "$already_added" = false ]; then
+            packages+=("$pkg_rel")
+        fi
+    done < <(find "$I18NIFY_DATA_DIR" -path "*/proto/*.proto" -type f \
+                ! -path "$I18NIFY_DATA_DIR/go/*" | sort)
+
+    # Output as JSON array
+    to_json_array "${packages[@]:-}"
+}
+
+# Given a base ref, output packages whose source data files changed.
+discover_changed_packages() {
+    local base_ref="$1"
+    local all_valid
+    all_valid=$(discover_all_packages)
+
+    # Get list of changed files under i18nify-data/ (exclude go/ output dir)
+    local changed_files
+    changed_files=$(git diff --name-only "$base_ref" -- \
+        "$I18NIFY_DATA_DIR" \
+        ':!i18nify-data/go' \
+        ':!i18nify-data/README.md' \
+        ':!i18nify-data/contribution-guidelines.md' \
+        ':!i18nify-data/versioning-policy.md' \
+        ':!i18nify-data/assets' \
+        ':!i18nify-data/media' \
+        2>/dev/null || true)
+
+    if [ -z "$changed_files" ]; then
+        echo "[]"
+        return
+    fi
+
+    # For each valid package, check if any changed file falls under its path
+    local matched=()
+    while IFS= read -r pkg; do
+        # pkg is e.g. "currency" or "country/subdivisions"
+        local pkg_prefix="i18nify-data/${pkg}/"
+        if echo "$changed_files" | grep -q "^${pkg_prefix}"; then
+            matched+=("$pkg")
+        fi
+    done < <(echo "$all_valid" | jq -r '.[]')
+
+    to_json_array "${matched[@]:-}"
+}
+
+# Validate a comma-separated list of user-provided package names.
+# Returns only those that exist as valid packages.
+validate_packages() {
+    local input="$1"
+    local all_valid
+    all_valid=$(discover_all_packages)
+
+    local validated=()
+    # Split on comma, trim whitespace
+    IFS=',' read -ra parts <<< "$input"
+    for part in "${parts[@]}"; do
+        local pkg
+        pkg="$(echo "$part" | xargs)" # trim whitespace
+        [ -z "$pkg" ] && continue
+
+        # Check if this is a known valid package
+        if echo "$all_valid" | jq -e --arg p "$pkg" 'index($p) != null' >/dev/null 2>&1; then
+            validated+=("$pkg")
+        else
+            echo "WARNING: '$pkg' is not a valid package (no proto found), skipping" >&2
+        fi
+    done
+
+    to_json_array "${validated[@]:-}"
+}
+
+# Convert a bash array to a JSON array string.
+to_json_array() {
+    if [ $# -eq 0 ] || [ -z "${1:-}" ]; then
+        echo "[]"
+        return
+    fi
+    # Use jq to safely produce JSON from arguments
+    printf '%s\n' "$@" | jq -R . | jq -s .
+}
+
+# --- Main ---
+MODE="${1:-}"
+
+case "$MODE" in
+    --all)
+        discover_all_packages
+        ;;
+    --changed)
+        BASE_REF="${2:-HEAD~1}"
+        discover_changed_packages "$BASE_REF"
+        ;;
+    --validate)
+        INPUT="${2:-}"
+        if [ -z "$INPUT" ]; then
+            echo "[]"
+        else
+            validate_packages "$INPUT"
+        fi
+        ;;
+    *)
+        echo "Usage: $0 {--all|--changed <base-ref>|--validate <csv>}" >&2
+        echo "" >&2
+        echo "Examples:" >&2
+        echo "  $0 --all                          # All valid packages" >&2
+        echo "  $0 --changed origin/master         # Packages with changes vs master" >&2
+        echo "  $0 --validate 'currency,bankcodes' # Validate user input" >&2
+        exit 1
+        ;;
+esac

--- a/.github/scripts/go/discover-packages.sh
+++ b/.github/scripts/go/discover-packages.sh
@@ -69,12 +69,12 @@ discover_changed_packages() {
     local all_valid
     all_valid=$(discover_all_packages)
 
-    # Get list of changed files under i18nify-data/ (exclude go/ output dir)
+    # Get list of changed files under i18nify-data/ (exclude non-data files)
     local changed_files
     changed_files=$(git diff --name-only "$base_ref" -- \
         "$I18NIFY_DATA_DIR" \
         ':!i18nify-data/go' \
-        ':!i18nify-data/README.md' \
+        ':!**/README.md' \
         ':!i18nify-data/contribution-guidelines.md' \
         ':!i18nify-data/versioning-policy.md' \
         ':!i18nify-data/assets' \

--- a/.github/workflows/auto-generate-go-packages.yml
+++ b/.github/workflows/auto-generate-go-packages.yml
@@ -67,21 +67,31 @@ jobs:
 
       - name: Set event metadata
         id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+          INPUT_RELEASE: ${{ github.event.inputs.release }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "branch=${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
-            echo "pr_number=" >> $GITHUB_OUTPUT
-            IS_RELEASE=${{ github.event.inputs.release == 'true' && github.event.inputs.branch == 'master' }}
-            echo "is_release=$IS_RELEASE" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
-            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            echo "is_release=false" >> $GITHUB_OUTPUT
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "branch=$INPUT_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            IS_RELEASE=false
+            if [ "$INPUT_RELEASE" = "true" ] && [ "$INPUT_BRANCH" = "master" ]; then
+              IS_RELEASE=true
+            fi
+            echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "branch=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
           else
             # push to master
-            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-            echo "pr_number=" >> $GITHUB_OUTPUT
-            echo "is_release=true" >> $GITHUB_OUTPUT
+            echo "branch=$REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install jq
@@ -89,23 +99,27 @@ jobs:
 
       - name: Resolve package list
         id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PACKAGE: ${{ github.event.inputs.package }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
         run: |
           chmod +x .github/scripts/go/discover-packages.sh
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            INPUT="${{ github.event.inputs.package }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            INPUT="$INPUT_PACKAGE"
             if [ "$INPUT" = "all" ] || [ -z "$INPUT" ]; then
               PACKAGES=$(.github/scripts/go/discover-packages.sh --all)
             else
               # Validate user-provided names against actual repo structure
               PACKAGES=$(.github/scripts/go/discover-packages.sh --validate "$INPUT")
             fi
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-            PACKAGES=$(.github/scripts/go/discover-packages.sh --changed "$BASE")
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            PACKAGES=$(.github/scripts/go/discover-packages.sh --changed "$PR_BASE_SHA")
           else
             # Push: compare against previous commit (before the push)
-            BEFORE="${{ github.event.before }}"
+            BEFORE="$PUSH_BEFORE"
             if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
               BEFORE="HEAD~1"
             fi
@@ -116,7 +130,7 @@ jobs:
 
           # Compact to single line for GitHub Actions output
           PACKAGES_ONELINE=$(echo "$PACKAGES" | jq -c .)
-          echo "packages=$PACKAGES_ONELINE" >> $GITHUB_OUTPUT
+          echo "packages=$PACKAGES_ONELINE" >> "$GITHUB_OUTPUT"
 
   # ─── Generate each package (matrix from discover output) ───────────────────────
   generate:

--- a/.github/workflows/auto-generate-go-packages.yml
+++ b/.github/workflows/auto-generate-go-packages.yml
@@ -6,38 +6,32 @@ on:
     branches:
       - master
     paths:
-      - 'i18nify-data/country/subdivisions/**'
-      - 'i18nify-data/currency/**'
-      - 'i18nify-data/bankcodes/**'
-      - 'i18nify-data/country/metadata/**'
-      - 'i18nify-data/phone-number/country-code-to-phone-number/**'
+      # Trigger on any data file change under i18nify-data/ (except generated output).
+      # The discover-packages.sh script narrows this to only valid packages.
+      - 'i18nify-data/**'
       - '!i18nify-data/go/**'
+      - '!i18nify-data/README.md'
+      - '!i18nify-data/assets/**'
+      - '!i18nify-data/media/**'
   push:
     branches:
       - master
     paths:
-      - 'i18nify-data/country/subdivisions/**'
-      - 'i18nify-data/currency/**'
-      - 'i18nify-data/bankcodes/**'
-      - 'i18nify-data/country/metadata/**'
-      - 'i18nify-data/phone-number/country-code-to-phone-number/**'
+      - 'i18nify-data/**'
       - '!i18nify-data/go/**'
+      - '!i18nify-data/README.md'
+      - '!i18nify-data/assets/**'
+      - '!i18nify-data/media/**'
 
-  # Manual trigger via GitHub Actions UI
+  # Manual trigger. Package list is now a free-text string (not a hardcoded choice)
+  # so new packages are picked up without workflow edits.
   workflow_dispatch:
     inputs:
       package:
-        description: 'Package to generate'
+        description: 'Package(s) to generate — "all" or comma-separated names (e.g. "currency, bankcodes")'
         required: false
-        type: choice
         default: 'all'
-        options:
-          - 'all'
-          - 'country/subdivisions'
-          - 'currency'
-          - 'bankcodes'
-          - 'country/metadata'
-          - 'phone-number/country-code-to-phone-number'
+        type: string
       branch:
         description: 'Branch to run on'
         required: true
@@ -57,97 +51,88 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # For PR/push: detect which packages have data changes
-  detect-changes:
-    name: Detect Data Changes
+  # ─── Discover which packages to generate ───────────────────────────────────────
+  discover:
+    name: Discover Packages
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
     outputs:
-      packages: ${{ steps.filter.outputs.changes || '[]' }}
-      branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      pr_number: ${{ github.event.pull_request.number }}
-      is_release: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      packages: ${{ steps.resolve.outputs.packages }}
+      branch: ${{ steps.meta.outputs.branch }}
+      pr_number: ${{ steps.meta.outputs.pr_number }}
+      is_release: ${{ steps.meta.outputs.is_release }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Check if triggering push has i18nify-data changes
-        id: trigger-check
+      - name: Set event metadata
+        id: meta
         run: |
-          BEFORE="${{ github.event.before }}"
-          if [ -z "$BEFORE" ]; then
-            echo "has_data_changes=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          git diff --name-only "$BEFORE" HEAD \
-            | grep -qE "^i18nify-data/(country/subdivisions|currency|bankcodes|country/metadata|phone-number/country-code-to-phone-number)/" \
-            && echo "has_data_changes=true" >> $GITHUB_OUTPUT \
-            || echo "has_data_changes=false" >> $GITHUB_OUTPUT
-
-      - uses: dorny/paths-filter@v3
-        id: filter
-        if: steps.trigger-check.outputs.has_data_changes == 'true'
-        with:
-          base: ${{ github.event.pull_request.base.ref || github.event.before || 'HEAD~1' }}
-          filters: |
-            country/subdivisions:
-              - 'i18nify-data/country/subdivisions/**'
-              - '!i18nify-data/country/subdivisions/README.md'
-            currency:
-              - 'i18nify-data/currency/**'
-              - '!i18nify-data/currency/README.md'
-            bankcodes:
-              - 'i18nify-data/bankcodes/**'
-              - '!i18nify-data/bankcodes/README.md'
-            country/metadata:
-              - 'i18nify-data/country/metadata/**'
-              - '!i18nify-data/country/metadata/README.md'
-            phone-number/country-code-to-phone-number:
-              - 'i18nify-data/phone-number/country-code-to-phone-number/**'
-
-  # For workflow_dispatch: get inputs
-  check-dispatch:
-    name: Parse Manual Dispatch
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
-    outputs:
-      packages: ${{ steps.parse.outputs.packages }}
-      branch: ${{ github.event.inputs.branch }}
-      is_release: ${{ github.event.inputs.release == 'true' && github.event.inputs.branch == 'master' }}
-    steps:
-      - name: Parse inputs
-        id: parse
-        env:
-          PACKAGE: ${{ github.event.inputs.package }}
-        run: |
-          if [ "$PACKAGE" != "all" ] && [ -n "$PACKAGE" ]; then
-            echo "packages=[\"$PACKAGE\"]" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "branch=${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
+            echo "pr_number=" >> $GITHUB_OUTPUT
+            IS_RELEASE=${{ github.event.inputs.release == 'true' && github.event.inputs.branch == 'master' }}
+            echo "is_release=$IS_RELEASE" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "is_release=false" >> $GITHUB_OUTPUT
           else
-            echo 'packages=["country/subdivisions","currency","bankcodes","country/metadata","phone-number/country-code-to-phone-number"]' >> $GITHUB_OUTPUT
+            # push to master
+            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "pr_number=" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
           fi
 
-  # Generate packages
+      - name: Install jq
+        run: command -v jq >/dev/null || sudo apt-get install -y jq
+
+      - name: Resolve package list
+        id: resolve
+        run: |
+          chmod +x .github/scripts/go/discover-packages.sh
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            INPUT="${{ github.event.inputs.package }}"
+            if [ "$INPUT" = "all" ] || [ -z "$INPUT" ]; then
+              PACKAGES=$(.github/scripts/go/discover-packages.sh --all)
+            else
+              # Validate user-provided names against actual repo structure
+              PACKAGES=$(.github/scripts/go/discover-packages.sh --validate "$INPUT")
+            fi
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            PACKAGES=$(.github/scripts/go/discover-packages.sh --changed "$BASE")
+          else
+            # Push: compare against previous commit (before the push)
+            BEFORE="${{ github.event.before }}"
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              BEFORE="HEAD~1"
+            fi
+            PACKAGES=$(.github/scripts/go/discover-packages.sh --changed "$BEFORE")
+          fi
+
+          echo "Discovered packages: $PACKAGES"
+
+          # Compact to single line for GitHub Actions output
+          PACKAGES_ONELINE=$(echo "$PACKAGES" | jq -c .)
+          echo "packages=$PACKAGES_ONELINE" >> $GITHUB_OUTPUT
+
+  # ─── Generate each package (matrix from discover output) ───────────────────────
   generate:
     name: Generate ${{ matrix.package }}
     runs-on: ubuntu-latest
-    needs: [detect-changes, check-dispatch]
-    if: |
-      always() && (
-        (needs.detect-changes.result == 'success' && needs.detect-changes.outputs.packages != '[]' && needs.detect-changes.outputs.packages != '') ||
-        (needs.check-dispatch.result == 'success')
-      )
+    needs: [discover]
+    if: needs.discover.outputs.packages != '[]' && needs.discover.outputs.packages != ''
     strategy:
       matrix:
-        package: ${{ fromJson(needs.check-dispatch.outputs.packages || needs.detect-changes.outputs.packages || '[]') }}
+        package: ${{ fromJson(needs.discover.outputs.packages) }}
       fail-fast: false
-    outputs:
-      released_packages: ${{ steps.release-tag.outputs.released_packages }}
 
     env:
-      BRANCH: ${{ needs.check-dispatch.outputs.branch || needs.detect-changes.outputs.branch }}
-      PR_NUMBER: ${{ needs.detect-changes.outputs.pr_number || '' }}
-      IS_RELEASE: ${{ needs.check-dispatch.outputs.is_release || needs.detect-changes.outputs.is_release }}
+      BRANCH: ${{ needs.discover.outputs.branch }}
+      PR_NUMBER: ${{ needs.discover.outputs.pr_number }}
+      IS_RELEASE: ${{ needs.discover.outputs.is_release }}
       GH_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
     steps:
@@ -271,14 +256,13 @@ jobs:
         run: |
           PACKAGE="${{ matrix.package }}"
           # Tag prefix must match the full module path for Go module resolution
-          # e.g. country/subdivisions -> i18nify-data/go/country/subdivisions/v1.0.0
           TAG_PREFIX="i18nify-data/go/$PACKAGE"
-          
+
           if [ "$IS_RELEASE" == "true" ]; then
             # For release: get latest tag and bump version
             git fetch --tags origin
             LATEST_TAG=$(git tag -l "${TAG_PREFIX}/v*" --sort=-version:refname | head -n 1 || echo "")
-            
+
             if [ -z "$LATEST_TAG" ]; then
               # No existing tag, start at v1.0.0
               NEW_VERSION="1.0.0"
@@ -292,7 +276,7 @@ jobs:
               NEW_PATCH=$((PATCH + 1))
               NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
             fi
-            
+
             echo "version=v${NEW_VERSION}" >> $GITHUB_OUTPUT
             echo "tag=${TAG_PREFIX}/v${NEW_VERSION}" >> $GITHUB_OUTPUT
             echo "is_release=true" >> $GITHUB_OUTPUT
@@ -302,7 +286,7 @@ jobs:
             SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-12)
             TIMESTAMP=$(TZ=UTC git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S "$COMMIT_SHA")
             VERSION="v0.0.0-${TIMESTAMP}-${SHORT_SHA}"
-            
+
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "tag=" >> $GITHUB_OUTPUT
             echo "is_release=false" >> $GITHUB_OUTPUT
@@ -314,10 +298,10 @@ jobs:
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           PACKAGE="${{ matrix.package }}"
-          
+
           git tag -a "$TAG" -m "Release $PACKAGE ${{ steps.version.outputs.version }}"
           git push origin "$TAG"
-          
+
           echo "Released $PACKAGE with tag $TAG"
           echo "released_packages=${PACKAGE}:${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
 
@@ -338,20 +322,20 @@ jobs:
           go get ${MODULE}@${VERSION}
           \`\`\`"
 
-  # Update go.mod once after all matrix jobs finish — avoids parallel push races
+  # ─── Update go.mod once after all matrix jobs finish ────────────────────────────
   update-go-mod:
     name: Update go.mod dependencies
     runs-on: ubuntu-latest
-    needs: [detect-changes, check-dispatch, generate]
+    needs: [discover, generate]
     if: |
-      always() && (
-        (needs.detect-changes.result == 'success' && needs.detect-changes.outputs.packages != '[]' && needs.detect-changes.outputs.packages != '') ||
-        (needs.check-dispatch.result == 'success')
-      ) && needs.generate.result == 'success'
+      always() &&
+      needs.discover.outputs.packages != '[]' &&
+      needs.discover.outputs.packages != '' &&
+      needs.generate.result == 'success'
     env:
-      BRANCH: ${{ needs.check-dispatch.outputs.branch || needs.detect-changes.outputs.branch }}
-      IS_RELEASE: ${{ needs.check-dispatch.outputs.is_release || needs.detect-changes.outputs.is_release }}
-      PACKAGES: ${{ needs.check-dispatch.outputs.packages || needs.detect-changes.outputs.packages }}
+      BRANCH: ${{ needs.discover.outputs.branch }}
+      IS_RELEASE: ${{ needs.discover.outputs.is_release }}
+      PACKAGES: ${{ needs.discover.outputs.packages }}
       GONOSUMDB: github.com/razorpay/i18nify
       GOPROXY: direct
       GH_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
@@ -442,14 +426,14 @@ jobs:
             git push origin HEAD:"$BRANCH"
           fi
 
-  # Release i18nify-go with updated dependencies (only on master push)
+  # ─── Release i18nify-go with updated dependencies (only on master push) ────────
   release-i18nify-go:
     name: Release i18nify-go
     runs-on: ubuntu-latest
-    needs: [detect-changes, update-go-mod]
+    needs: [discover, update-go-mod]
     if: |
       always() &&
-      needs.detect-changes.outputs.is_release == 'true' &&
+      needs.discover.outputs.is_release == 'true' &&
       needs.update-go-mod.result == 'success'
 
     steps:
@@ -480,7 +464,7 @@ jobs:
       - name: Bump and tag i18nify-go release
         env:
           CURRENT_VERSION: ${{ steps.current-version.outputs.version }}
-          PACKAGES: ${{ needs.detect-changes.outputs.packages }}
+          PACKAGES: ${{ needs.discover.outputs.packages }}
         run: |
           IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
           NEW_VERSION="${VERSION_PARTS[0]}.$((VERSION_PARTS[1] + 1)).0"


### PR DESCRIPTION
## Summary

- Removes all hardcoded package names from the `auto-generate-go-packages` workflow
- Adds `.github/scripts/go/discover-packages.sh` that scans repo structure to find valid packages (any `i18nify-data/<pkg>/proto/*.proto`)
- Replaces `dorny/paths-filter` + split `detect-changes`/`check-dispatch` jobs with a single unified `discover` job
- Changes `workflow_dispatch` input from `choice` (hardcoded dropdown) to `string` (accepts "all" or comma-separated package names)

## How it works

A package is valid when `i18nify-data/<pkg>/proto/*.proto` exists. The script has three modes:
- `--all` — list every valid package
- `--changed <base-ref>` — only packages with file diffs vs base
- `--validate <csv>` — validate user-provided names, warn on invalid

New packages added under `i18nify-data/` are picked up automatically without any workflow edits.

## Recursion safety

Bot commits go to `i18nify-data/go/` (excluded by path filter) and `packages/i18nify-go/` (outside trigger path). No actor check needed — path filters alone prevent re-triggering.

## Manual dispatch examples

| Input | Behaviour |
|---|---|
| `all` | All packages with protos |
| `currency` | Just currency |
| `currency, bankcodes` | Those two |
| `currency, fake-pkg` | currency only, warns about fake-pkg |

## Test plan

- [x] `discover-packages.sh --all` returns all 6 packages
- [x] `--changed` correctly detects only affected packages
- [x] `--changed` ignores `i18nify-data/go/` (bot output)
- [x] `--validate` filters invalid names with warnings
- [x] Empty diff returns `[]`, skipping the generate matrix
- [x] JSON output is valid for `fromJson()` matrix expansion
- [x] YAML parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)