### PR TITLE
fix(ci): restore js release push auth

### DIFF
--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC
-  contents: read
+  contents: write
 
 env:
   GITHUB_ACCESS_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.CI_BOT_TOKEN }}
       - name: Use Node v20
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Summary
- restore write access for the js release workflow token
- make checkout use `CI_BOT_TOKEN` so changesets pushes with the bot token instead of `github-actions[bot]`

## Root cause
The release workflow was explicitly downgraded to `contents: read`, and checkout was not configured with `CI_BOT_TOKEN`. That left the repo remote authenticated as `github-actions[bot]`, so the changesets step failed on:

`git push origin HEAD:changeset-release/master --force`

with a 403.

## Testing
- not run; workflow-only change