### PR TITLE
fix(go): restore reachable subdivisions version

### DIFF
--- a/packages/i18nify-go/go.mod
+++ b/packages/i18nify-go/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v1.0.3
 	github.com/razorpay/i18nify/i18nify-data/go/business_entity v0.0.0-20260630122543-7e86a2db2139
 	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v1.0.6
-	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260716110201-577f12ea7b6d
+	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v1.0.7
 	github.com/razorpay/i18nify/i18nify-data/go/currency v1.0.5
 	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v1.0.3
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
## Summary

- replace the unreachable country/subdivisions pseudo-version with the existing v1.0.7 tag
- unblock downstream consumer module resolution and consumer integration tests

## Root cause

The pseudo-version referenced commit 577f12ea7b6d from the deleted feat/business-entity-combined branch. After squash merge, Go could no longer resolve that revision through VCS and failed with `invalid version: unknown revision 577f12ea7b6d`.

## Verification

- `go mod tidy`
- `go test ./...` in `packages/i18nify-go`