### PR TITLE
fix(go): pin data modules to reachable release tags

### DIFF
--- a/packages/i18nify-go/go.mod
+++ b/packages/i18nify-go/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/razorpay/i18nify/i18nify-data/go/bankcodes v1.0.3
-	github.com/razorpay/i18nify/i18nify-data/go/business_entity v0.0.0-20260630122543-7e86a2db2139
+	github.com/razorpay/i18nify/i18nify-data/go/business_entity v1.0.0
 	github.com/razorpay/i18nify/i18nify-data/go/country/metadata v1.0.6
-	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v0.0.0-20260818095336-eb167d02b811
+	github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v1.0.8
 	github.com/razorpay/i18nify/i18nify-data/go/currency v1.0.5
 	github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v1.0.3
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/packages/i18nify-go/go.sum
+++ b/packages/i18nify-go/go.sum
@@ -7,12 +7,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/razorpay/i18nify/i18nify-data/go/bankcodes v1.0.3 h1:buNThlDg9YE1aHhUegIU/4AgX5/p+6o0Xg7fdlpfyFs=
 github.com/razorpay/i18nify/i18nify-data/go/bankcodes v1.0.3/go.mod h1:IIGgMZsudL2XeV/k2wJzNvne80aU5n7FLK+Eybq+Jeg=
-github.com/razorpay/i18nify/i18nify-data/go/business_entity v0.0.0-20260630122543-7e86a2db2139 h1:eE6jYzwAwisJGWl9xKh8r7OE+FcfoUwyFxMNsslb7Gw=
-github.com/razorpay/i18nify/i18nify-data/go/business_entity v0.0.0-20260630122543-7e86a2db2139/go.mod h1:tULF2+5sG1ea9dthj+EP7fIETGaR6s+wY0MIIfjQ3wo=
+github.com/razorpay/i18nify/i18nify-data/go/business_entity v1.0.0 h1:getU+WYvN0Zz5uy+eDOHXtUQib83J1tb43caLRFArGc=
+github.com/razorpay/i18nify/i18nify-data/go/business_entity v1.0.0/go.mod h1:tULF2+5sG1ea9dthj+EP7fIETGaR6s+wY0MIIfjQ3wo=
 github.com/razorpay/i18nify/i18nify-data/go/country/metadata v1.0.6 h1:HOJ68S+j+f/WqOOYDstY1gi6nMx4v8B6Fd2mKYKXPOI=
 github.com/razorpay/i18nify/i18nify-data/go/country/metadata v1.0.6/go.mod h1:8/bUffLHRUapN6J4R61kcaOZKr8yjKb0YXrlpCumy0g=
-github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v1.0.7 h1:+xtUlU1HXy9e73IOMxMA8HnpPF7COzz76nmeRMLVQzg=
-github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v1.0.7/go.mod h1:Co4OyvFG2HC9ohJbdw8Ydqd1Y7MJHCBAw9Ee8U1Cfxw=
+github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v1.0.8 h1:TreyxatUzPDjT9WuSR8Paindwa8CUs3cIaQz1b/Y2ec=
+github.com/razorpay/i18nify/i18nify-data/go/country/subdivisions v1.0.8/go.mod h1:Co4OyvFG2HC9ohJbdw8Ydqd1Y7MJHCBAw9Ee8U1Cfxw=
 github.com/razorpay/i18nify/i18nify-data/go/currency v1.0.5 h1:WdbG4qmKFqr42SOm/jJNp9j/UJt/q0A5eiaweetmibM=
 github.com/razorpay/i18nify/i18nify-data/go/currency v1.0.5/go.mod h1:hVdGzMUMfaZS0AwsHBaHENYxqYWYrfpRnYW7mJeRDB8=
 github.com/razorpay/i18nify/i18nify-data/go/phone-number/country-code-to-phone-number v1.0.3 h1:Ze1O/o5XFgNYpBI1S8oH/RoOic57p57999ee5uvTT2w=


### PR DESCRIPTION
## Problem

The [Auto-Generate Go Packages run](https://github.com/razorpay/i18nify/actions/runs/32124386131/job/95675083766) failed on the `Update go.mod for all changed packages` step:

```
github.com/razorpay/i18nify/i18nify-data/go/business_entity@v0.0.0-20260630122543-7e86a2db2139:
  invalid version: unknown revision 7e86a2db2139
```

`packages/i18nify-go/go.mod` referenced two data modules by pseudo-version whose underlying commits no longer exist:

| Module | Stale ref | Reachable? |
| --- | --- | --- |
| `i18nify-data/go/business_entity` | `v0.0.0-20260630122543-7e86a2db2139` | no |
| `i18nify-data/go/country/subdivisions` | `v0.0.0-20260818095336-eb167d02b811` | no |

Both SHAs came from PR branches that were squash-merged, so the original commits were garbage collected and the refs became unresolvable.

The release path of the workflow runs `go mod tidy`, which resolves the **entire** module graph — so the dead `business_entity` ref failed a run that was only meant to bump `country/subdivisions`. The downstream `Release i18nify-go` job never ran as a result.

The `subdivisions` entry was masked in that run (the release step rewrites it to a tag before `tidy`), but it is equally unreachable and would break any non-release CI path.

## Fix

Pin both modules to their published release tags:

- `business_entity` → `v1.0.0`
- `country/subdivisions` → `v1.0.8`

## Verification

`go mod tidy`, `go build ./...` and `go test ./...` all pass locally:

```
ok  	.../modules/bankcodes                        2.000s
ok  	.../modules/business_entity                  0.614s
ok  	.../modules/country_metadata                 0.896s
ok  	.../modules/country_subdivisions             2.186s
ok  	.../modules/country_subdivisions/zipcode     3.205s
ok  	.../modules/currency                         1.651s
ok  	.../modules/phonenumber                      2.451s
```

## Follow-up (not in this PR)

This is the same class of failure as #749. `.github/scripts/go/update-dependencies.sh` pins to branch HEAD SHAs, so every squash-merge can orphan the ref it just wrote. Worth hardening separately:

1. Prefer the release tag whenever `i18nify-data/go/<pkg>/vX.Y.Z` exists, instead of writing a pseudo-version.
2. Add a CI guard that runs `git cat-file -e <sha>` over every pseudo-version in `go.mod`, so this fails fast with a clear message rather than a cryptic `go mod tidy` error weeks later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)