### PR TITLE
feat: Added formatting SDK for php

### DIFF
--- a/.github/workflows/php-release.yml
+++ b/.github/workflows/php-release.yml
@@ -1,0 +1,200 @@
+name: i18nify PHP Release
+
+# Packagist cannot serve a package that lives in a monorepo subdirectory, so the
+# release flow mirrors the Go one: on a master merge we (1) copy the canonical
+# dataset into the package, (2) split packages/i18nify-php
+# into the read-only mirror repo razorpay/i18nify-php, (3) tag both the monorepo
+# (i18nify-php/vX.Y.Z) and the mirror (vX.Y.Z). Packagist tracks the mirror and
+# picks up the new tag from its GitHub webhook.
+#
+# Version bumping is the changeset equivalent for PHP: the bump level comes from
+# the PR label (php:major / php:minor / php:patch), defaulting to patch, and the
+# version itself is derived from git tags — composer.json carries no version
+# field, which is what Packagist expects.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'packages/i18nify-php/**'
+      - 'i18nify-data/currency/**'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump level'
+        required: true
+        default: 'patch'
+        type: choice
+        options: [patch, minor, major]
+      dry_run:
+        description: 'Build and split but do not tag or notify Packagist'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: php-release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PACKAGE_DIR: packages/i18nify-php
+  MIRROR_REPO: razorpay/i18nify-php
+  TAG_PREFIX: i18nify-php
+
+jobs:
+  release:
+    name: Release razorpay/i18nify-php
+    runs-on: ubuntu-latest # nosemgrep: non-self-hosted-runner
+
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CI_BOT_TOKEN }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: intl, json
+          coverage: none
+          tools: composer:v2
+
+      # Guard: never publish a broken package.
+      - name: Materialise canonical dataset
+        run: |
+          chmod +x scripts/php/sync-data.sh
+          scripts/php/sync-data.sh --deref
+
+      - name: Validate and test
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: |
+          composer validate --strict --no-check-lock
+          composer install --prefer-dist --no-interaction --no-progress
+          vendor/bin/phpunit --colors=always
+
+      - name: Resolve next version
+        id: version
+        env:
+          BUMP_INPUT: ${{ github.event.inputs.bump }}
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+        run: |
+          git fetch --tags origin
+
+          LATEST_TAG=$(git tag -l "${TAG_PREFIX}/v*" --sort=-version:refname | head -n 1 || echo "")
+
+          if [ -z "$LATEST_TAG" ]; then
+            CURRENT="0.0.0"
+          else
+            CURRENT="${LATEST_TAG#${TAG_PREFIX}/v}"
+          fi
+
+          # Bump level: workflow input, else the merged PR's php:* label, else patch.
+          BUMP="patch"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            BUMP="$BUMP_INPUT"
+          else
+            PR_NUMBER=$(gh pr list --search "${{ github.sha }}" --state merged --json number --jq '.[0].number' || echo "")
+            if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+              LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' || echo "")
+              case "$LABELS" in
+                *php:major*) BUMP="major" ;;
+                *php:minor*) BUMP="minor" ;;
+                *)           BUMP="patch" ;;
+              esac
+            fi
+          fi
+
+          IFS='.' read -ra P <<< "$CURRENT"
+          MAJOR="${P[0]:-0}"; MINOR="${P[1]:-0}"; PATCH="${P[2]:-0}"
+
+          case "$BUMP" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+
+          NEW="${MAJOR}.${MINOR}.${PATCH}"
+
+          echo "Current: ${CURRENT} | bump: ${BUMP} | new: ${NEW}"
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "version=v${NEW}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG_PREFIX}/v${NEW}" >> "$GITHUB_OUTPUT"
+
+      # Remove dev-only files so the mirror repo contains a clean library, and
+      # un-ignore the materialised dataset — it is a build artefact in the
+      # monorepo but a shipped file in the published package.
+      - name: Prepare split payload
+        run: |
+          rm -rf "${PACKAGE_DIR}/vendor" "${PACKAGE_DIR}/.phpunit.cache"
+          rm -f  "${PACKAGE_DIR}/composer.lock"
+
+          # Drop the src/Currency/data/ ignore rule (and its comment block) so
+          # the split repo commits the dataset.
+          sed -i '/^# Build artefact/,$d' "${PACKAGE_DIR}/.gitignore"
+
+          DATA="${PACKAGE_DIR}/src/Currency/data/currency.json"
+          test -f "$DATA"
+          test ! -L "$DATA"
+          grep -q 'src/Currency/data' "${PACKAGE_DIR}/.gitignore" \
+            && { echo "✗ dataset still gitignored — the published package would be broken" >&2; exit 1; } \
+            || echo "✓ dataset will be committed to the mirror"
+
+      - name: Split into ${{ env.MIRROR_REPO }}
+        uses: symplify/monorepo-split-github-action@v2.3.0
+        if: github.event.inputs.dry_run != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+        with:
+          package_directory: ${{ env.PACKAGE_DIR }}
+          repository_organization: razorpay
+          repository_name: i18nify-php
+          branch: master
+          tag: ${{ steps.version.outputs.version }}
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Tag the monorepo
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git tag -a "${{ steps.version.outputs.tag }}" \
+            -m "Release i18nify-php ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      # Packagist normally picks the tag up from the mirror's own webhook. This
+      # is a belt-and-braces nudge; it no-ops if the secrets are unset.
+      - name: Notify Packagist
+        if: github.event.inputs.dry_run != 'true'
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+        run: |
+          if [ -z "$PACKAGIST_USERNAME" ] || [ -z "$PACKAGIST_TOKEN" ]; then
+            echo "ℹ️ Packagist credentials not configured — relying on the mirror repo webhook."
+            exit 0
+          fi
+          curl -sSf -XPOST \
+            -H 'content-type:application/json' \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+            -d "{\"repository\":{\"url\":\"https://github.com/${MIRROR_REPO}\"}}"
+
+      - name: Summary
+        run: |
+          {
+            echo "## 📦 razorpay/i18nify-php released"
+            echo ""
+            echo "- **Version:** \`${{ steps.version.outputs.version }}\` (${{ steps.version.outputs.bump }})"
+            echo "- **Monorepo tag:** \`${{ steps.version.outputs.tag }}\`"
+            echo "- **Mirror:** https://github.com/${MIRROR_REPO}"
+            echo ""
+            echo '```bash'
+            echo "composer require razorpay/i18nify-php:^${{ steps.version.outputs.version }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/php-validate.yml
+++ b/.github/workflows/php-validate.yml
@@ -1,0 +1,69 @@
+name: i18nify PHP Validate
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'packages/i18nify-php/**'
+      - 'i18nify-data/currency/**'
+      - 'scripts/php/**'
+      - '.github/workflows/php-validate.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'packages/i18nify-php/**'
+      - 'i18nify-data/currency/**'
+      - 'scripts/php/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest # nosemgrep: non-self-hosted-runner
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4', '8.1', '8.3']
+
+    defaults:
+      run:
+        working-directory: packages/i18nify-php
+
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: intl, json
+          coverage: none
+          tools: composer:v2
+
+      # The package reads i18nify-data/currency/data.json directly and keeps no
+      # copy of it. This asserts the canonical file is valid and that no copy
+      # has crept into the package.
+      - name: Verify canonical dataset
+        working-directory: .
+        run: |
+          chmod +x scripts/php/sync-data.sh
+          scripts/php/sync-data.sh
+
+      - name: Validate composer.json
+        run: composer validate --strict --no-check-lock
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --colors=always
+
+      # Guards the core promise of the package: PHP output must equal JS output
+      # for the same locale and fraction digits (both are ICU/CLDR under the hood).
+      - name: Cross-SDK parity check (PHP vs JS Intl)
+        if: matrix.php == '8.3'
+        working-directory: .
+        run: |
+          chmod +x scripts/php/parity-check.sh
+          scripts/php/parity-check.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Why
 
-Razorpay operates across multiple countries and currencies. Products built on Razorpay need to handle locale-aware formatting, country-specific phone numbers, geographic data, and banking identifiers without each team building their own solutions. i18nify centralizes this — a single source of truth for i18n data and utilities, shared across JavaScript, React, and Go codebases.
+Razorpay operates across multiple countries and currencies. Products built on Razorpay need to handle locale-aware formatting, country-specific phone numbers, geographic data, and banking identifiers without each team building their own solutions. i18nify centralizes this — a single source of truth for i18n data and utilities, shared across JavaScript, React, Go, and PHP codebases.
 
 ## What
 
@@ -10,14 +10,18 @@ A monorepo providing internationalization primitives: currency formatting and co
 
 ## Repo Structure
 
-Yarn monorepo (`yarn workspaces`). Three packages + one central dataset:
+Yarn monorepo (`yarn workspaces`). Four packages + one central dataset:
 
 | Path | Package | Purpose |
 |---|---|---|
 | `packages/i18nify-js/` | `@razorpay/i18nify-js` | Core JS/TS library |
 | `packages/i18nify-react/` | `@razorpay/i18nify-react` | React context provider wrapping i18nify-js |
 | `packages/i18nify-go/` | Go module | Go implementation |
+| `packages/i18nify-php/` | `razorpay/i18nify-php` (Composer) | PHP implementation (currency module) |
 | `i18nify-data/` | — | Canonical JSON dataset (source of truth for all packages) |
+
+`i18nify-php` is not a yarn workspace — it has no `package.json`. It is built,
+tested and released by its own workflows (`php-validate.yml`, `php-release.yml`).
 
 ## Architecture
 
@@ -30,7 +34,12 @@ i18nify-data/ (canonical JSON)
       ├── Runtime (JS): geo/banking functions fetch directly from GitHub raw CDN
       │   at https://raw.githubusercontent.com/razorpay/i18nify/master/i18nify-data
       │
-      └── Compile-time (Go): //go:embed bundles JSON files into the binary
+      ├── Compile-time (Go): //go:embed bundles JSON files into the binary
+      │
+      └── In place (PHP): read directly from i18nify-data/currency/data.json —
+          no copy in the package. The release pipeline copies it into the
+          published dist (scripts/php/sync-data.sh --deref) so Composer
+          installs are self-contained
 ```
 
 ## Key Constraint
@@ -46,10 +55,19 @@ yarn workspace @razorpay/i18nify-js run validate # tsc + lint
 yarn validate                                    # validates all packages
 ```
 
+```
+cd packages/i18nify-php && composer test  # PHPUnit for the PHP package
+scripts/php/sync-data.sh                  # verify the PHP package has no dataset copy
+```
+
 **Any PR that changes `i18nify-js` or `i18nify-react` must include a changeset:**
 ```
 yarn changeset   # interactive: select package, bump type, describe change
 ```
+
+Changesets is npm-only. **PRs that change `i18nify-php` version it via a
+`php:major` / `php:minor` / `php:patch` label (default patch) and an entry in
+`packages/i18nify-php/CHANGELOG.md`.**
 
 For package-specific commands (React, data validation, releases) see the relevant agent doc.
 
@@ -61,3 +79,4 @@ Before working on a specific area, read the relevant doc:
 - `agent_docs/data-pipeline.md` — how i18nify-data feeds into bundled JS subsets; how to add/update data
 - `agent_docs/geo-banking.md` — geo and banking module details; remote fetch pattern; supported countries
 - `agent_docs/go-package.md` — i18nify-go structure, embed pattern, caching, bank identifier types
+- `agent_docs/php-package.md` — i18nify-php structure, dataset symlink, locale resolution, Packagist release flow

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To get started with i18nify, please refer to the language-specific README files:
 - [Go](./packages/i18nify-go/readme.md)
 - [JavaScript](./packages/i18nify-js/README.md)
 - [React](./packages/i18nify-react/README.md)
+- [PHP](./packages/i18nify-php/README.md)
 
 ## Dataset
 

--- a/agent_docs/php-package.md
+++ b/agent_docs/php-package.md
@@ -1,0 +1,144 @@
+# i18nify-php
+
+PHP SDK, `packages/i18nify-php/`. Composer package name: `razorpay/i18nify-php`.
+
+## Why it exists
+
+The API monolith needed locale-correct invoice amount formatting for non-Indian
+currencies. i18nify shipped JS and Go only, so the first cut of that work
+hand-ported the currency module into `api/app/lib/I18nify/` and vendored a copy
+of `i18nify-data/currency/data.json` alongside it. That is two sources of truth
+for one behaviour. This package is the fix: i18nify owns the data *and* the
+formatting logic, and the monolith keeps only thin wiring.
+
+## Layout
+
+```
+packages/i18nify-php/
+├── composer.json                        # PSR-4: RZP\I18nify\ -> src/
+├── phpunit.xml
+├── src/Currency/
+│   ├── Currency.php                     # public API (mirrors i18nify-js surface)
+│   └── FormatNumber.php                 # NumberFormatter, locale resolution, parts assembly
+└── tests/CurrencyTest.php
+```
+
+No `data/` directory in git — the dataset is read from `i18nify-data/`.
+
+`FormatNumber.php` is the counterpart of i18nify-go's `format_number.go`. It is
+not named `format_number.php` because PSR-4 autoloading requires the filename to
+match the class name.
+
+## Architecture
+
+Three SDKs, one dataset, one formatting engine per language binding:
+
+```
+i18nify-data/currency/data.json (canonical)
+      │
+      ├── JS:  prebuild strips it into src/modules/currency/data/currencyConfig.json
+      ├── Go:  //go:embed via the generated i18nify-data/go/currency module
+      └── PHP: read in place with file_get_contents — no copy in the package
+```
+
+Formatting itself is ICU/CLDR in all three: `Intl.NumberFormat` (JS),
+`golang.org/x/text` (Go), `ext-intl` `NumberFormatter` (PHP). Same locale + same
+fraction digits therefore produce the same string, which
+`scripts/php/parity-check.sh` asserts in CI against Node.
+
+## Where the data comes from
+
+There is **no dataset file in this package's git tree**. `Currency::resolveDataPath()`
+picks the first hit from, in order:
+
+1. `$I18NIFY_CURRENCY_DATA_PATH` / `Currency::setDataPath()` — explicit override.
+2. `__DIR__/../../../../i18nify-data/currency/data.json` — the canonical file,
+   used whenever the package sits inside the monorepo (local dev, CI, a
+   `path`-type composer repository). Read in place, so it cannot drift.
+3. `__DIR__/data/currency.json` — dist-local copy. Exists only in the published
+   package, produced by `scripts/php/sync-data.sh --deref` during release.
+
+`scripts/php/sync-data.sh`:
+
+| Invocation | What it does |
+|---|---|
+| (no args) | Verifies the canonical file parses **and** that `src/Currency/data/currency.json` is not tracked in git. CI runs this before the tests. |
+| `--deref` | Copies the canonical file into the package. Release only. |
+| `--clean` | Removes the copy. |
+
+`src/Currency/data/` is gitignored. The release job strips that ignore rule from
+the copied `.gitignore` before splitting, otherwise the mirror repo would commit
+a package with no data in it — there is an explicit assertion for this in
+`php-release.yml`.
+
+If you add another module (phone-number, country, …) add its mapping to the
+`MAPPINGS` array in `scripts/php/sync-data.sh` and a candidate path in
+`Currency::DATA_PATH_CANDIDATES`-style resolution for that module. Never commit
+a copy.
+
+## Locale resolution
+
+| Caller                                                      | Locale when omitted                       |
+| ----------------------------------------------------------- | ----------------------------------------- |
+| `formatNumber()`, `formatNumberByParts()`                    | `Currency::DEFAULT_LOCALE` = `en-IN`      |
+| `formatNumberWithoutSymbol()`, `formatSubunitsWithoutSymbol()` | `FormatNumber::localeForCurrency($code)`  |
+
+`localeForCurrency()` is the mapping that used to live in the monolith:
+`INR -> en-IN` (lakh/crore), everything else `-> en-US` (international). Add
+overrides to `FormatNumber::$currencyDisplayLocales`, not at call sites.
+
+Unknown currency codes degrade rather than throw: 2 minor units, prefix symbol,
+code used as its own symbol. `isValidCurrencyCode()` is there when a caller
+needs strictness.
+
+## Commands
+
+```bash
+cd packages/i18nify-php
+composer install
+composer test                      # phpunit
+composer validate --strict
+
+# from repo root
+scripts/php/sync-data.sh           # verify canonical dataset, assert no copy in the package
+scripts/php/sync-data.sh --deref   # materialise the dist copy (release only)
+scripts/php/sync-data.sh --clean   # remove the dist copy
+scripts/php/parity-check.sh        # PHP vs JS Intl output diff (needs php+intl+node)
+```
+
+## Release
+
+Packagist cannot serve a package from a monorepo subdirectory, so releases
+mirror the Go flow — see `.github/workflows/php-release.yml`:
+
+1. `sync-data.sh --deref` copies the canonical dataset into the package.
+2. `composer validate` + PHPUnit gate the release.
+3. Version resolved from the latest `i18nify-php/v*` tag, bumped by the merged
+   PR's `php:major` / `php:minor` / `php:patch` label (default patch). This is
+   the changeset equivalent — changesets itself is npm-only and ignores this
+   package. Record the human-readable entry in
+   `packages/i18nify-php/CHANGELOG.md`.
+4. `symplify/monorepo-split-github-action` pushes `packages/i18nify-php/` to the
+   read-only mirror `razorpay/i18nify-php` and tags it `vX.Y.Z`.
+5. The monorepo is tagged `i18nify-php/vX.Y.Z`.
+6. Packagist picks up the mirror tag from its GitHub webhook; the workflow also
+   POSTs to the Packagist update API when `PACKAGIST_USERNAME` /
+   `PACKAGIST_TOKEN` are configured.
+
+**One-time setup required before the first release:** create the
+`razorpay/i18nify-php` mirror repo, submit it to Packagist (the package name in
+`composer.json` matches the mirror repo name, so there is nothing to reconcile),
+and give `CI_BOT_TOKEN` write access to the mirror. If public Packagist is not acceptable, point an internal Satis/Private
+Packagist instance at the mirror instead — nothing else in the flow changes.
+
+`composer.json` deliberately carries **no** `version` field; Packagist derives
+it from tags.
+
+## Consuming from the API monolith
+
+```php
+use RZP\I18nify\Currency\Currency;
+
+// subunits in, display string out — replaces the local FormatsInvoiceAmounts logic
+Currency::formatSubunitsWithoutSymbol($amount, $invoice->getCurrency());
+```

--- a/packages/i18nify-php/.gitignore
+++ b/packages/i18nify-php/.gitignore
@@ -1,0 +1,11 @@
+vendor/
+composer.lock
+.phpunit.cache/
+.phpunit.result.cache
+coverage/
+
+# Build artefact: the canonical dataset lives at i18nify-data/currency/data.json
+# and is read from there in the monorepo. The release pipeline copies it here
+# (scripts/php/sync-data.sh --deref) only so published Composer installs are
+# self-contained. Never commit it.
+src/Currency/data/

--- a/packages/i18nify-php/README.md
+++ b/packages/i18nify-php/README.md
@@ -1,0 +1,89 @@
+# razorpay/i18nify-php
+
+The PHP SDK for [i18nify](https://github.com/razorpay/i18nify). Same data, same
+behaviour as `@razorpay/i18nify-js` and `i18nify-go` — currently the currency
+module (formatting and unit conversion).
+
+Formatting runs on PHP's `intl` extension, which binds to the same ICU/CLDR
+engine behind JS `Intl.NumberFormat`, so output matches the JS and Go SDKs for
+the same locale and fraction digits.
+
+## Install
+
+```bash
+composer require razorpay/i18nify-php
+```
+
+Requires PHP >= 7.4 and `ext-intl`.
+
+## Usage
+
+```php
+use RZP\I18nify\Currency\Currency;
+
+// Subunits in, display-ready string out (symbol rendered separately by templates)
+Currency::formatSubunitsWithoutSymbol(12345678, 'INR');   // '1,23,456.78'
+Currency::formatSubunitsWithoutSymbol(12345678, 'MYR');   // '123,456.78'
+Currency::formatSubunitsWithoutSymbol(12345678, 'JPY');   // '12,345,678'
+Currency::formatSubunitsWithoutSymbol(12345678, 'KWD');   // '12,345.678'
+
+// Explicit locale
+Currency::formatNumberWithoutSymbol(123456.78, ['currency' => 'SGD', 'locale' => 'en-US']);
+// '123,456.78'
+
+// With the canonical i18nify symbol
+Currency::formatNumber(123456.78, ['currency' => 'MYR', 'locale' => 'en-US']);
+// 'RM123,456.78'
+
+// Structured breakdown (mirrors the JS ByParts type)
+Currency::formatNumberByParts(-123456.78, ['currency' => 'MYR', 'locale' => 'en-US']);
+// ['integer' => '123,456', 'decimal' => '.', 'fraction' => '78',
+//  'currency' => 'RM', 'minusSign' => '-', 'isPrefixSymbol' => true, 'rawParts' => [...]]
+
+// Unit conversion and metadata
+Currency::convertToMajorUnit(12345678, 'MYR');   // 123456.78
+Currency::convertToMinorUnit(123456.78, 'MYR');  // 12345678.0
+Currency::getMinorUnit('KWD');                   // 3
+Currency::getCurrencySymbol('SGD');              // 'S$'
+Currency::isValidCurrencyCode('ZZZ');            // false
+```
+
+### Display locale
+
+When `locale` is omitted from `formatNumberWithoutSymbol()` /
+`formatSubunitsWithoutSymbol()`, it is derived from the currency:
+
+| Currency | Locale  | Grouping                        |
+| -------- | ------- | ------------------------------- |
+| INR      | `en-IN` | lakh/crore — `1,23,456.78`      |
+| all else | `en-US` | international — `123,456.78`    |
+
+`formatNumber()` and `formatNumberByParts()` fall back to
+`Currency::DEFAULT_LOCALE` (`en-IN`), matching `i18nify-go` and `i18nify-js`.
+
+Unknown currency codes degrade gracefully: 2 minor units, prefix symbol, code
+used as the symbol. Use `isValidCurrencyCode()` when you need strictness.
+
+## Data
+
+Currency metadata comes from the canonical dataset at
+`i18nify-data/currency/data.json`. There is no copy of it in this package's
+source tree — inside the monorepo the SDK reads that file in place, so the JS,
+Go and PHP SDKs can never disagree about the data. The release pipeline copies
+it into the published package so Composer installs are self-contained.
+
+To point the SDK at a dataset somewhere else (shared volume, config-managed
+path, test fixture), set `I18NIFY_CURRENCY_DATA_PATH` or call
+`Currency::setDataPath('/path/to/data.json')`. `Currency::resolveDataPath()`
+reports which file is in use.
+
+## Development
+
+```bash
+cd packages/i18nify-php
+composer install
+composer test
+```
+
+`scripts/php/sync-data.sh` (from the repo root) verifies the canonical dataset
+and fails if a copy has crept into the package.

--- a/packages/i18nify-php/composer.json
+++ b/packages/i18nify-php/composer.json
@@ -1,0 +1,39 @@
+{
+  "name": "razorpay/i18nify-php",
+  "description": "Razorpay i18nify PHP SDK (currency formatting)",
+  "type": "library",
+  "license": "MIT",
+  "keywords": ["i18n", "currency", "formatting", "intl", "razorpay"],
+  "homepage": "https://github.com/razorpay/i18nify",
+  "support": {
+    "issues": "https://github.com/razorpay/i18nify/issues",
+    "source": "https://github.com/razorpay/i18nify/tree/master/packages/i18nify-php"
+  },
+  "autoload": {
+    "psr-4": {
+      "RZP\\I18nify\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "RZP\\I18nify\\Tests\\": "tests/"
+    }
+  },
+  "require": {
+    "php": ">=7.4",
+    "ext-intl": "*",
+    "ext-json": "*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
+  },
+  "scripts": {
+    "test": "phpunit",
+    "validate-data": "php -r \"require 'vendor/autoload.php'; echo RZP\\\\I18nify\\\\Currency\\\\Currency::resolveDataPath(), PHP_EOL; exit(count(RZP\\\\I18nify\\\\Currency\\\\Currency::getCurrencyList()) > 0 ? 0 : 1);\""
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true
+}

--- a/packages/i18nify-php/phpunit.xml
+++ b/packages/i18nify-php/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResultFile=".phpunit.cache/test-results"
+         failOnRisky="true"
+         beStrictAboutTestsThatDoNotTestAnything="true">
+  <testsuites>
+    <testsuite name="i18nify-php">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+</phpunit>

--- a/packages/i18nify-php/src/Currency/Currency.php
+++ b/packages/i18nify-php/src/Currency/Currency.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RZP\I18nify\Currency;
+
+use InvalidArgumentException;
+
+/**
+ * i18nify currency module — PHP.
+ *
+ * Public API mirrors i18nify-js (`packages/i18nify-js/src/modules/currency`) and
+ * i18nify-go (`packages/i18nify-go/modules/currency`): formatNumber,
+ * formatNumberByParts, convertToMajorUnit, convertToMinorUnit, getCurrencySymbol,
+ * getMinorUnit.
+ *
+ * PHP's NumberFormatter (ext-intl) binds to the same ICU/CLDR engine that backs
+ * the JS Intl.NumberFormat used by i18nify, so formatted output is identical
+ * across the three SDKs for the same locale and fraction digits.
+ *
+ * Currency metadata is read straight from the canonical i18nify dataset at
+ * `i18nify-data/currency/data.json`. This package keeps no copy of it in git —
+ * inside the monorepo the file is read in place, and the release pipeline
+ * materialises it into the published dist (which is not a git artefact). See
+ * agent_docs/php-package.md.
+ *
+ * @see https://github.com/razorpay/i18nify/blob/master/i18nify-data/currency/data.json
+ */
+class Currency
+{
+    /**
+     * Default locale when the caller does not pass one.
+     * Matches i18nify-go's `defaultLocale` and the JS default.
+     */
+    public const DEFAULT_LOCALE = 'en-IN';
+
+    public const SYMBOL_POSITION_PREFIX = 'prefix';
+
+    public const SYMBOL_POSITION_SUFFIX = 'suffix';
+
+    /**
+     * Fallback minor unit for currency codes absent from the dataset.
+     */
+    public const DEFAULT_MINOR_UNIT = 2;
+
+    /**
+     * Environment variable that overrides dataset discovery entirely.
+     * Useful when the dataset is deployed outside the package (shared volume,
+     * config-managed path, test fixture).
+     */
+    public const DATA_PATH_ENV = 'I18NIFY_CURRENCY_DATA_PATH';
+
+    /**
+     * Candidate locations for the currency dataset, in priority order.
+     *
+     * 1. The canonical file in the i18nify monorepo — used when this package is
+     *    consumed in place (local dev, CI, `path` composer repositories). Read
+     *    directly, so there is never a second copy to keep in sync.
+     * 2. A dist-local copy at `src/Currency/data/currency.json`. This path does
+     *    not exist in git; the release pipeline materialises it so that
+     *    Composer installs are self-contained.
+     */
+    private const DATA_PATH_CANDIDATES = [
+        __DIR__ . '/../../../../i18nify-data/currency/data.json',
+        __DIR__ . '/data/currency.json',
+    ];
+
+    /**
+     * Explicit dataset path set via setDataPath().
+     *
+     * @var string|null
+     */
+    private static $dataPath = null;
+
+    /**
+     * Parsed i18nify-data currency information, keyed by ISO 4217 alpha code.
+     *
+     * @var array<string, array<string, mixed>>|null
+     */
+    private static $currencyInformation = null;
+
+    /**
+     * Points the SDK at a specific dataset file. Takes precedence over the
+     * environment variable and the built-in candidates.
+     */
+    public static function setDataPath(?string $path): void
+    {
+        self::$dataPath = $path;
+
+        self::$currencyInformation = null;
+    }
+
+    /**
+     * Absolute path of the dataset this process will read.
+     */
+    public static function resolveDataPath(): string
+    {
+        $explicit = self::$dataPath ?? (getenv(self::DATA_PATH_ENV) ?: null);
+
+        if ($explicit !== null) {
+            if (is_file($explicit) === false) {
+                throw new \RuntimeException(sprintf(
+                    'i18nify currency dataset not found at the configured path "%s".',
+                    $explicit
+                ));
+            }
+
+            return realpath($explicit) ?: $explicit;
+        }
+
+        foreach (self::DATA_PATH_CANDIDATES as $candidate) {
+            if (is_file($candidate)) {
+                // Normalise the ../.. walk so diagnostics and error messages
+                // show a path a human can act on.
+                return realpath($candidate) ?: $candidate;
+            }
+        }
+
+        throw new \RuntimeException(
+            'i18nify currency dataset not found. Looked in: '
+            . implode(', ', array_map([self::class, 'normalisePath'], self::DATA_PATH_CANDIDATES))
+            . '. Inside the i18nify monorepo the canonical file is i18nify-data/currency/data.json; '
+            . 'for a packaged install run scripts/php/sync-data.sh --deref, or set the '
+            . self::DATA_PATH_ENV . ' environment variable.'
+        );
+    }
+
+    /**
+     * Collapses `a/b/../c` segments for readable diagnostics. Unlike realpath()
+     * this works on paths that do not exist, which is exactly the case when we
+     * are reporting where we failed to find the dataset.
+     */
+    private static function normalisePath(string $path): string
+    {
+        $isAbsolute = strpos($path, DIRECTORY_SEPARATOR) === 0;
+
+        $segments = [];
+
+        foreach (explode(DIRECTORY_SEPARATOR, $path) as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+
+            if ($segment === '..' && $segments !== [] && end($segments) !== '..') {
+                array_pop($segments);
+
+                continue;
+            }
+
+            $segments[] = $segment;
+        }
+
+        return ($isAbsolute ? DIRECTORY_SEPARATOR : '') . implode(DIRECTORY_SEPARATOR, $segments);
+    }
+
+    /**
+     * All currency information from the canonical dataset, keyed by ISO code.
+     *
+     * Mirrors i18nify-js getCurrencyList().
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function getCurrencyList(): array
+    {
+        if (self::$currencyInformation === null) {
+            $path = self::resolveDataPath();
+
+            $json = @file_get_contents($path);
+
+            if ($json === false) {
+                throw new \RuntimeException('i18nify currency dataset at ' . $path . ' could not be read.');
+            }
+
+            $decoded = json_decode($json, true);
+
+            if (is_array($decoded) === false || isset($decoded['currency_information']) === false) {
+                throw new \RuntimeException('i18nify currency dataset at ' . $path . ' is malformed.');
+            }
+
+            self::$currencyInformation = $decoded['currency_information'];
+        }
+
+        return self::$currencyInformation;
+    }
+
+    /**
+     * Currency information for a single ISO code.
+     *
+     * Unknown codes fall back to a 2-minor-unit, prefix-symbol shape using the
+     * code itself as the symbol, so formatting never hard-fails on an
+     * unrecognised currency. Use isValidCurrencyCode() when you need strictness.
+     *
+     * Mirrors i18nify-js getCurrencyList()[$currencyCode].
+     *
+     * @return array<string, mixed>
+     */
+    public static function getCurrencyInformation(string $currencyCode): array
+    {
+        $code = strtoupper($currencyCode);
+
+        $list = self::getCurrencyList();
+
+        return $list[$code] ?? [
+            'name'            => $code,
+            'minor_unit'      => (string) self::DEFAULT_MINOR_UNIT,
+            'symbol'          => $code,
+            'symbol_position' => self::SYMBOL_POSITION_PREFIX,
+        ];
+    }
+
+    /**
+     * Whether the code exists in the canonical i18nify dataset.
+     *
+     * Mirrors i18nify-js isValidCurrencyCode().
+     */
+    public static function isValidCurrencyCode(string $currencyCode): bool
+    {
+        if ($currencyCode === '') {
+            return false;
+        }
+
+        return isset(self::getCurrencyList()[strtoupper($currencyCode)]);
+    }
+
+    /**
+     * Number of decimal places the currency subdivides into (ISO 4217 minor unit).
+     * E.g. INR/USD -> 2, JPY -> 0, KWD -> 3.
+     */
+    public static function getMinorUnit(string $currencyCode): int
+    {
+        return (int) self::getCurrencyInformation($currencyCode)['minor_unit'];
+    }
+
+    /**
+     * Mirrors i18nify-js getCurrencySymbol(currencyCode).
+     */
+    public static function getCurrencySymbol(string $currencyCode): string
+    {
+        return (string) self::getCurrencyInformation($currencyCode)['symbol'];
+    }
+
+    /**
+     * Whether the currency symbol precedes the number for this currency.
+     */
+    public static function isPrefixSymbol(string $currencyCode): bool
+    {
+        $position = self::getCurrencyInformation($currencyCode)['symbol_position'] ?? self::SYMBOL_POSITION_PREFIX;
+
+        return $position === self::SYMBOL_POSITION_PREFIX;
+    }
+
+    /**
+     * Converts a subunit amount to major units.
+     * E.g. 12345678 subunits of MYR -> 123456.78
+     *
+     * Mirrors i18nify-js convertToMajorUnit(amount, {currency}).
+     *
+     * @param int|float|string $amount Amount in currency subunits
+     */
+    public static function convertToMajorUnit($amount, string $currencyCode): float
+    {
+        return self::assertNumeric($amount) / (10 ** self::getMinorUnit($currencyCode));
+    }
+
+    /**
+     * Converts a major-unit amount to subunits.
+     * E.g. 123456.78 MYR -> 12345678
+     *
+     * Mirrors i18nify-js convertToMinorUnit(amount, {currency}).
+     *
+     * @param int|float|string $amount Amount in major units
+     */
+    public static function convertToMinorUnit($amount, string $currencyCode): float
+    {
+        return round(self::assertNumeric($amount) * (10 ** self::getMinorUnit($currencyCode)));
+    }
+
+    /**
+     * Structured breakdown of the formatted number.
+     *
+     * Keys mirror the i18nify-js ByParts type: integer, decimal, fraction,
+     * currency, minusSign, isPrefixSymbol, rawParts.
+     *
+     * Mirrors i18nify-js formatNumberByParts(amount, {currency, locale, intlOptions}).
+     *
+     * @param int|float|string     $amount  Amount in major units
+     * @param array<string, mixed> $options currency, locale, intlOptions
+     *
+     * @return array<string, mixed>
+     */
+    public static function formatNumberByParts($amount, array $options = []): array
+    {
+        return FormatNumber::toParts(self::assertNumeric($amount), $options);
+    }
+
+    /**
+     * Locale-aware number string including the canonical i18nify currency symbol.
+     * E.g. formatNumber(123456.78, ['currency' => 'MYR', 'locale' => 'en-US']) -> 'RM123,456.78'
+     *
+     * Mirrors i18nify-js formatNumber(amount, {currency, locale, intlOptions}).
+     *
+     * @param int|float|string     $amount  Amount in major units
+     * @param array<string, mixed> $options currency, locale, intlOptions
+     */
+    public static function formatNumber($amount, array $options = []): string
+    {
+        $parts = self::formatNumberByParts($amount, $options);
+
+        return implode('', array_column($parts['rawParts'], 'value'));
+    }
+
+    /**
+     * Locale-aware number string WITHOUT the currency symbol — the shape hosted
+     * pages, invoices, PDFs and email templates need, since they render the
+     * symbol separately.
+     *
+     * When 'locale' is omitted the display locale is derived from the currency
+     * (INR keeps Indian lakh/crore grouping, everything else uses international
+     * grouping). See FormatNumber::localeForCurrency().
+     *
+     * PHP-only addition; i18nify-js callers compose this from formatNumberByParts().
+     *
+     * @param int|float|string     $amount  Amount in major units
+     * @param array<string, mixed> $options currency, locale, intlOptions
+     */
+    public static function formatNumberWithoutSymbol($amount, array $options = []): string
+    {
+        if (isset($options['locale']) === false && isset($options['currency']) === true) {
+            $options['locale'] = FormatNumber::localeForCurrency((string) $options['currency']);
+        }
+
+        $parts = self::formatNumberByParts($amount, $options);
+
+        return $parts['minusSign'] . $parts['integer'] . $parts['decimal'] . $parts['fraction'];
+    }
+
+    /**
+     * Convenience: subunits in, display-ready number string out (no symbol).
+     * Collapses convertToMajorUnit() + formatNumberWithoutSymbol() for the
+     * common invoice/hosted-page case.
+     *
+     * @param int|float|string $amount Amount in currency subunits
+     */
+    public static function formatSubunitsWithoutSymbol($amount, string $currencyCode, ?string $locale = null): string
+    {
+        $options = ['currency' => $currencyCode];
+
+        if ($locale !== null) {
+            $options['locale'] = $locale;
+        }
+
+        return self::formatNumberWithoutSymbol(self::convertToMajorUnit($amount, $currencyCode), $options);
+    }
+
+    /**
+     * Resets the in-process dataset cache. Test/CLI helper.
+     */
+    public static function flushCache(): void
+    {
+        self::$currencyInformation = null;
+
+        FormatNumber::flushCache();
+    }
+
+    /**
+     * @param int|float|string $amount
+     */
+    private static function assertNumeric($amount): float
+    {
+        if (is_numeric($amount) === false) {
+            throw new InvalidArgumentException(sprintf(
+                "Parameter 'amount' is not a valid number. The received value was: %s of type %s.",
+                var_export($amount, true),
+                gettype($amount)
+            ));
+        }
+
+        return (float) $amount;
+    }
+}

--- a/packages/i18nify-php/src/Currency/FormatNumber.php
+++ b/packages/i18nify-php/src/Currency/FormatNumber.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RZP\I18nify\Currency;
+
+use NumberFormatter;
+use RuntimeException;
+
+/**
+ * Number formatting engine for the currency module.
+ *
+ * Everything locale- and grouping-related lives here: display-locale resolution
+ * per currency, the cached ext-intl NumberFormatter instances, and the assembly
+ * of Intl-style formatted parts. Currency::formatNumber* delegates to this
+ * class, so consumers never construct a NumberFormatter themselves.
+ *
+ * Counterpart of i18nify-go's `format_number.go` / `format_number_helpers.go`.
+ * (Named FormatNumber.php rather than format_number.php because PSR-4
+ * autoloading requires the filename to match the class name.)
+ */
+class FormatNumber
+{
+    /**
+     * Display locale for currencies without a specific override.
+     * International (thousands) grouping.
+     */
+    public const DEFAULT_DISPLAY_LOCALE = 'en-US';
+
+    /**
+     * Per-currency display locale for number grouping. INR keeps the Indian
+     * lakh/crore grouping; every other currency uses international grouping.
+     *
+     * This is the mapping that used to live in the API monolith's
+     * FormatsInvoiceAmounts trait — it belongs with the formatting logic.
+     *
+     * @var array<string, string>
+     */
+    private static $currencyDisplayLocales = [
+        'INR' => 'en-IN',
+    ];
+
+    /**
+     * @var array<string, NumberFormatter> Cache keyed by locale + fraction digits
+     */
+    private static $formatters = [];
+
+    /**
+     * Display locale to use for a currency when the caller does not pass one.
+     *
+     * E.g. INR -> 'en-IN' (1,23,456.78), MYR/SGD/USD -> 'en-US' (123,456.78).
+     */
+    public static function localeForCurrency(string $currencyCode): string
+    {
+        return self::$currencyDisplayLocales[strtoupper($currencyCode)] ?? self::DEFAULT_DISPLAY_LOCALE;
+    }
+
+    /**
+     * Formats $amount and returns the Intl-style structured breakdown.
+     *
+     * @param array<string, mixed> $options currency, locale, intlOptions
+     *
+     * @return array<string, mixed>
+     */
+    public static function toParts(float $amount, array $options = []): array
+    {
+        self::assertIntlAvailable();
+
+        // ICU locale ids use underscores; accept BCP 47 tags for parity with JS.
+        $locale = str_replace('-', '_', (string) ($options['locale'] ?? Currency::DEFAULT_LOCALE));
+
+        $currency = isset($options['currency']) ? strtoupper((string) $options['currency']) : null;
+
+        $defaultFractionDigits = ($currency === null)
+            ? Currency::DEFAULT_MINOR_UNIT
+            : Currency::getMinorUnit($currency);
+
+        $intlOptions = $options['intlOptions'] ?? [];
+
+        $minFractionDigits = (int) ($intlOptions['minimumFractionDigits'] ?? $defaultFractionDigits);
+        $maxFractionDigits = (int) ($intlOptions['maximumFractionDigits'] ?? $defaultFractionDigits);
+
+        $useGrouping = $intlOptions['useGrouping'] ?? true;
+
+        $formatter = self::formatter($locale, $minFractionDigits, $maxFractionDigits, (bool) $useGrouping);
+
+        $formatted = $formatter->format(abs($amount));
+
+        if ($formatted === false) {
+            throw new RuntimeException(sprintf(
+                'Failed to format amount for locale "%s": %s',
+                $locale,
+                $formatter->getErrorMessage()
+            ));
+        }
+
+        $decimalSeparator = $formatter->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+
+        $separatorPos = ($decimalSeparator === '' || $decimalSeparator === false)
+            ? false
+            : strrpos($formatted, $decimalSeparator);
+
+        if (($maxFractionDigits > 0) && ($separatorPos !== false)) {
+            $integer  = substr($formatted, 0, $separatorPos);
+            $decimal  = $decimalSeparator;
+            $fraction = substr($formatted, $separatorPos + strlen($decimalSeparator));
+        } else {
+            $integer  = $formatted;
+            $decimal  = '';
+            $fraction = '';
+        }
+
+        $minusSign = ($amount < 0) ? '-' : '';
+
+        $symbol = ($currency === null) ? '' : Currency::getCurrencySymbol($currency);
+
+        $isPrefixSymbol = ($currency === null) ? true : Currency::isPrefixSymbol($currency);
+
+        $rawParts = [];
+
+        if ($minusSign !== '') {
+            $rawParts[] = ['type' => 'minusSign', 'value' => $minusSign];
+        }
+
+        if (($symbol !== '') && ($isPrefixSymbol === true)) {
+            $rawParts[] = ['type' => 'currency', 'value' => $symbol];
+        }
+
+        $rawParts[] = ['type' => 'integer', 'value' => $integer];
+
+        if ($decimal !== '') {
+            $rawParts[] = ['type' => 'decimal', 'value' => $decimal];
+            $rawParts[] = ['type' => 'fraction', 'value' => $fraction];
+        }
+
+        if (($symbol !== '') && ($isPrefixSymbol === false)) {
+            $rawParts[] = ['type' => 'currency', 'value' => $symbol];
+        }
+
+        return [
+            'integer'        => $integer,
+            'decimal'        => $decimal,
+            'fraction'       => $fraction,
+            'currency'       => $symbol,
+            'minusSign'      => $minusSign,
+            'isPrefixSymbol' => $isPrefixSymbol,
+            'rawParts'       => $rawParts,
+        ];
+    }
+
+    /**
+     * Cached decimal NumberFormatter for a locale + fraction-digit combination.
+     */
+    public static function formatter(
+        string $locale,
+        int $minFractionDigits,
+        int $maxFractionDigits,
+        bool $useGrouping = true
+    ): NumberFormatter {
+        $key = implode('|', [$locale, $minFractionDigits, $maxFractionDigits, $useGrouping ? '1' : '0']);
+
+        if (isset(self::$formatters[$key]) === false) {
+            $formatter = new NumberFormatter($locale, NumberFormatter::DECIMAL);
+
+            $formatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $minFractionDigits);
+            $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxFractionDigits);
+            $formatter->setAttribute(NumberFormatter::GROUPING_USED, $useGrouping ? 1 : 0);
+
+            self::$formatters[$key] = $formatter;
+        }
+
+        return self::$formatters[$key];
+    }
+
+    /**
+     * Clears the formatter cache. Test/CLI helper.
+     */
+    public static function flushCache(): void
+    {
+        self::$formatters = [];
+    }
+
+    private static function assertIntlAvailable(): void
+    {
+        if (class_exists(NumberFormatter::class) === false) {
+            throw new RuntimeException(
+                'razorpay/i18nify-php requires the intl PHP extension (ext-intl) for currency formatting.'
+            );
+        }
+    }
+}

--- a/packages/i18nify-php/tests/CurrencyTest.php
+++ b/packages/i18nify-php/tests/CurrencyTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RZP\I18nify\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use RZP\I18nify\Currency\Currency;
+use RZP\I18nify\Currency\FormatNumber;
+
+class CurrencyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Currency::flushCache();
+    }
+
+    /**
+     * @dataProvider getFormatNumberWithoutSymbolTestData
+     */
+    public function testFormatNumberWithoutSymbol(
+        string $expected,
+        int $subunits,
+        string $currency,
+        string $locale
+    ): void {
+        $major = Currency::convertToMajorUnit($subunits, $currency);
+
+        $actual = Currency::formatNumberWithoutSymbol($major, [
+            'currency' => $currency,
+            'locale'   => $locale,
+        ]);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @return array<int, array{0: string, 1: int, 2: string, 3: string}>
+     */
+    public function getFormatNumberWithoutSymbolTestData(): array
+    {
+        return [
+            // [Expected]        [Subunits]   [Currency] [Locale]
+            // INR keeps lakh/crore grouping
+            ['0.00',             0,           'INR', 'en-IN'],
+            ['1.23',             123,         'INR', 'en-IN'],
+            ['1,23,456.78',      12345678,    'INR', 'en-IN'],
+            ['1,23,45,678.90',   1234567890,  'INR', 'en-IN'],
+            ['-1,23,456.78',     -12345678,   'INR', 'en-IN'],
+
+            // International grouping per currency
+            ['123,456.78',       12345678,    'MYR', 'en-US'],
+            ['123,456.78',       12345678,    'SGD', 'en-US'],
+            ['123,456.78',       12345678,    'USD', 'en-US'],
+            ['12,345,678.90',    1234567890,  'MYR', 'en-US'],
+            ['-123,456.78',      -12345678,   'SGD', 'en-US'],
+
+            // Zero minor unit currency
+            ['12,345,678',       12345678,    'JPY', 'en-US'],
+
+            // Three minor unit currency
+            ['12,345.678',       12345678,    'KWD', 'en-US'],
+        ];
+    }
+
+    /**
+     * The locale mapping ported from the API monolith's FormatsInvoiceAmounts
+     * trait now lives in this package: callers only pass the currency.
+     *
+     * @dataProvider getCurrencyDerivedLocaleTestData
+     */
+    public function testFormatNumberWithoutSymbolDerivesLocaleFromCurrency(
+        string $expected,
+        int $subunits,
+        string $currency
+    ): void {
+        $this->assertSame($expected, Currency::formatSubunitsWithoutSymbol($subunits, $currency));
+    }
+
+    /**
+     * @return array<int, array{0: string, 1: int, 2: string}>
+     */
+    public function getCurrencyDerivedLocaleTestData(): array
+    {
+        return [
+            ['1,23,456.78',    12345678,   'INR'],
+            ['1,23,45,678.90', 1234567890, 'INR'],
+            ['123,456.78',     12345678,   'MYR'],
+            ['123,456.78',     12345678,   'SGD'],
+            ['123,456.78',     12345678,   'USD'],
+            ['12,345,678',     12345678,   'JPY'],
+            ['12,345.678',     12345678,   'KWD'],
+        ];
+    }
+
+    public function testLocaleForCurrency(): void
+    {
+        $this->assertSame('en-IN', FormatNumber::localeForCurrency('INR'));
+        $this->assertSame('en-IN', FormatNumber::localeForCurrency('inr'));
+        $this->assertSame('en-US', FormatNumber::localeForCurrency('MYR'));
+        $this->assertSame('en-US', FormatNumber::localeForCurrency('SGD'));
+        $this->assertSame('en-US', FormatNumber::localeForCurrency('ZZZ'));
+    }
+
+    public function testConvertToMajorUnit(): void
+    {
+        $this->assertSame(123456.78, Currency::convertToMajorUnit(12345678, 'MYR'));
+        $this->assertSame(12345678.0, Currency::convertToMajorUnit(12345678, 'JPY'));
+        $this->assertSame(12345.678, Currency::convertToMajorUnit(12345678, 'KWD'));
+        $this->assertSame(0.0, Currency::convertToMajorUnit(0, 'INR'));
+        $this->assertSame(-1234.56, Currency::convertToMajorUnit(-123456, 'INR'));
+    }
+
+    public function testConvertToMinorUnit(): void
+    {
+        $this->assertSame(12345678.0, Currency::convertToMinorUnit(123456.78, 'MYR'));
+        $this->assertSame(12345678.0, Currency::convertToMinorUnit(12345678, 'JPY'));
+        $this->assertSame(12345678.0, Currency::convertToMinorUnit(12345.678, 'KWD'));
+    }
+
+    public function testGetMinorUnit(): void
+    {
+        $this->assertSame(2, Currency::getMinorUnit('INR'));
+        $this->assertSame(2, Currency::getMinorUnit('MYR'));
+        $this->assertSame(0, Currency::getMinorUnit('JPY'));
+        $this->assertSame(3, Currency::getMinorUnit('KWD'));
+        $this->assertSame(2, Currency::getMinorUnit('ZZZ'), 'unknown codes fall back to 2 minor units');
+    }
+
+    public function testGetCurrencySymbol(): void
+    {
+        $this->assertSame('RM', Currency::getCurrencySymbol('MYR'));
+        $this->assertSame('S$', Currency::getCurrencySymbol('SGD'));
+        $this->assertSame('₹', Currency::getCurrencySymbol('INR'));
+        $this->assertSame('$', Currency::getCurrencySymbol('USD'));
+        $this->assertSame('¥', Currency::getCurrencySymbol('JPY'));
+    }
+
+    public function testIsValidCurrencyCode(): void
+    {
+        $this->assertTrue(Currency::isValidCurrencyCode('INR'));
+        $this->assertTrue(Currency::isValidCurrencyCode('myr'));
+        $this->assertFalse(Currency::isValidCurrencyCode('ZZZ'));
+        $this->assertFalse(Currency::isValidCurrencyCode(''));
+    }
+
+    public function testFormatNumberIncludesSymbol(): void
+    {
+        $this->assertSame('RM123,456.78', Currency::formatNumber(123456.78, [
+            'currency' => 'MYR',
+            'locale'   => 'en-US',
+        ]));
+
+        $this->assertSame('₹1,23,456.78', Currency::formatNumber(123456.78, [
+            'currency' => 'INR',
+            'locale'   => 'en-IN',
+        ]));
+
+        $this->assertSame('-$123,456.78', Currency::formatNumber(-123456.78, [
+            'currency' => 'USD',
+            'locale'   => 'en-US',
+        ]));
+    }
+
+    public function testFormatNumberPlacesSuffixSymbolAfterTheNumber(): void
+    {
+        // EUR is marked symbol_position: suffix in i18nify-data
+        $this->assertSame('123,456.78€', Currency::formatNumber(123456.78, [
+            'currency' => 'EUR',
+            'locale'   => 'en-US',
+        ]));
+    }
+
+    public function testFormatNumberWithoutCurrencyUsesDefaultLocale(): void
+    {
+        // Currency::DEFAULT_LOCALE is en-IN, matching i18nify-go and i18nify-js
+        $this->assertSame('1,23,456.78', Currency::formatNumber(123456.78));
+    }
+
+    public function testFormatNumberByPartsShape(): void
+    {
+        $parts = Currency::formatNumberByParts(-123456.78, [
+            'currency' => 'MYR',
+            'locale'   => 'en-US',
+        ]);
+
+        $this->assertSame('123,456', $parts['integer']);
+        $this->assertSame('.', $parts['decimal']);
+        $this->assertSame('78', $parts['fraction']);
+        $this->assertSame('RM', $parts['currency']);
+        $this->assertSame('-', $parts['minusSign']);
+        $this->assertTrue($parts['isPrefixSymbol']);
+
+        $this->assertSame(
+            [
+                ['type' => 'minusSign', 'value' => '-'],
+                ['type' => 'currency',  'value' => 'RM'],
+                ['type' => 'integer',   'value' => '123,456'],
+                ['type' => 'decimal',   'value' => '.'],
+                ['type' => 'fraction',  'value' => '78'],
+            ],
+            $parts['rawParts']
+        );
+    }
+
+    public function testIntlOptionsOverrideFractionDigits(): void
+    {
+        $this->assertSame('123,457', Currency::formatNumberWithoutSymbol(123456.78, [
+            'currency'    => 'USD',
+            'locale'      => 'en-US',
+            'intlOptions' => ['minimumFractionDigits' => 0, 'maximumFractionDigits' => 0],
+        ]));
+
+        $this->assertSame('123456.78', Currency::formatNumberWithoutSymbol(123456.78, [
+            'currency'    => 'USD',
+            'locale'      => 'en-US',
+            'intlOptions' => ['useGrouping' => false],
+        ]));
+    }
+
+    public function testUnknownCurrencyFallsBackToTwoMinorUnits(): void
+    {
+        $this->assertSame('123,456.78', Currency::formatNumberWithoutSymbol(123456.78, [
+            'currency' => 'ZZZ',
+            'locale'   => 'en-US',
+        ]));
+    }
+
+    public function testFormattingIsCaseInsensitiveOnCurrencyCode(): void
+    {
+        $this->assertSame(
+            Currency::formatSubunitsWithoutSymbol(12345678, 'INR'),
+            Currency::formatSubunitsWithoutSymbol(12345678, 'inr')
+        );
+    }
+
+    public function testNonNumericAmountIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Currency::formatNumber('not-a-number', ['currency' => 'INR']);
+    }
+
+    public function testDataSetIsTheCanonicalI18nifyData(): void
+    {
+        // In the monorepo the SDK must read i18nify-data/currency/data.json in
+        // place — no copy inside the package.
+        $this->assertSame(
+            realpath(__DIR__ . '/../../../i18nify-data/currency/data.json'),
+            realpath(Currency::resolveDataPath()),
+            'the PHP SDK should read the canonical i18nify dataset directly'
+        );
+
+        $list = Currency::getCurrencyList();
+
+        $this->assertArrayHasKey('INR', $list);
+        $this->assertArrayHasKey('minor_unit', $list['INR']);
+        $this->assertArrayHasKey('numeric_code', $list['INR']);
+        $this->assertArrayHasKey('symbol', $list['INR']);
+        $this->assertArrayHasKey('symbol_position', $list['INR']);
+        $this->assertGreaterThan(150, count($list));
+    }
+}

--- a/scripts/php/parity-check.sh
+++ b/scripts/php/parity-check.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Cross-SDK parity check: the PHP SDK must produce the same number strings as
+# the JS SDK for the same locale and fraction digits. Both sit on ICU/CLDR
+# (ext-intl and Intl.NumberFormat respectively), so a divergence here means the
+# PHP port has drifted from i18nify-js rather than a CLDR difference.
+#
+# Compares RZP\I18nify\Currency\Currency::formatNumberWithoutSymbol() against
+# Node's Intl.NumberFormat decimal output. Two deliberate scope limits:
+#   * The currency symbol is excluded — every i18nify SDK overrides Intl's
+#     symbol with the dataset value, so it is not an ICU behaviour worth diffing.
+#   * Locales are limited to en-* (Latin digits, stable CLDR grouping). PHP and
+#     Node bundle independent ICU versions, and comparing locales whose
+#     separators or numbering systems changed between CLDR releases produces
+#     failures that say nothing about this package.
+#
+# Usage: scripts/php/parity-check.sh
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PKG_DIR="$REPO_ROOT/packages/i18nify-php"
+
+command -v php >/dev/null || { echo "✗ php not found on PATH" >&2; exit 1; }
+command -v node >/dev/null || { echo "✗ node not found on PATH" >&2; exit 1; }
+php -m | grep -qix 'intl' || { echo "✗ ext-intl is not loaded" >&2; exit 1; }
+
+# amount(major)|currency|locale
+CASES=$(cat <<'EOF'
+0|INR|en-IN
+1.23|INR|en-IN
+123456.78|INR|en-IN
+12345678.9|INR|en-IN
+-123456.78|INR|en-IN
+99999999.99|INR|en-IN
+123456.78|MYR|en-US
+123456.78|SGD|en-US
+123456.78|USD|en-US
+12345678.9|MYR|en-US
+-123456.78|SGD|en-US
+12345678|JPY|en-US
+12345.678|KWD|en-US
+1234.5|BHD|en-US
+987654321.05|USD|en-GB
+987654321.05|USD|en-AU
+EOF
+)
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+printf '%s\n' "$CASES" > "$TMP_DIR/cases.txt"
+
+php -r '
+require $argv[1] . "/vendor/autoload.php";
+
+use RZP\I18nify\Currency\Currency;
+
+$out = fopen($argv[3], "w");
+
+foreach (file($argv[2], FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+    list($amount, $currency, $locale) = explode("|", $line);
+
+    fwrite($out, $line . "\t" . Currency::formatNumberWithoutSymbol((float) $amount, [
+        "currency" => $currency,
+        "locale"   => $locale,
+    ]) . "\n");
+}
+
+fclose($out);
+' "$PKG_DIR" "$TMP_DIR/cases.txt" "$TMP_DIR/php.tsv"
+
+node -e '
+const fs = require("fs");
+const [casesFile, dataFile, outFile] = process.argv.slice(1);
+const info = JSON.parse(fs.readFileSync(dataFile, "utf8")).currency_information;
+
+const lines = fs
+  .readFileSync(casesFile, "utf8")
+  .trim()
+  .split("\n")
+  .map((line) => {
+    const [amount, currency, locale] = line.split("|");
+    const entry = info[currency];
+    const minorUnit = Number(entry ? entry.minor_unit : 2);
+    const formatted = new Intl.NumberFormat(locale, {
+      style: "decimal",
+      minimumFractionDigits: minorUnit,
+      maximumFractionDigits: minorUnit,
+    }).format(Number(amount));
+    return line + "\t" + formatted;
+  });
+
+fs.writeFileSync(outFile, lines.join("\n") + "\n");
+' "$TMP_DIR/cases.txt" "$REPO_ROOT/i18nify-data/currency/data.json" "$TMP_DIR/js.tsv"
+
+if diff -u "$TMP_DIR/js.tsv" "$TMP_DIR/php.tsv" > "$TMP_DIR/diff.txt"; then
+  echo "✓ PHP and JS number formatting agree on $(grep -c . "$TMP_DIR/cases.txt") cases"
+else
+  echo "✗ PHP and JS number formatting diverge (- = JS, + = PHP):" >&2
+  cat "$TMP_DIR/diff.txt" >&2
+  exit 1
+fi

--- a/scripts/php/sync-data.sh
+++ b/scripts/php/sync-data.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Dataset plumbing for packages/i18nify-php.
+#
+# The PHP SDK reads i18nify-data/currency/data.json directly — there is no copy
+# of it committed inside the package. Composer installs, however, cannot see the
+# monorepo, so the release pipeline materialises the file into the package
+# directory just before it is split and tagged. That copy is a build artefact
+# and is gitignored.
+#
+# Usage:
+#   scripts/php/sync-data.sh            # verify (dev/CI): canonical file is present and parseable
+#   scripts/php/sync-data.sh --deref    # release: copy the canonical file into the package
+#   scripts/php/sync-data.sh --clean    # remove the materialised copy
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# canonical (source of truth) : dist location inside the PHP package
+declare -a MAPPINGS=(
+  "i18nify-data/currency/data.json:packages/i18nify-php/src/Currency/data/currency.json"
+)
+
+MODE="verify"
+case "${1:-}" in
+  --deref) MODE="deref" ;;
+  --clean) MODE="clean" ;;
+  "")      MODE="verify" ;;
+  *)       echo "unknown argument: $1 (expected --deref, --clean, or none)" >&2; exit 2 ;;
+esac
+
+for mapping in "${MAPPINGS[@]}"; do
+  SRC_REL="${mapping%%:*}"
+  DST_REL="${mapping##*:}"
+  SRC="$REPO_ROOT/$SRC_REL"
+  DST="$REPO_ROOT/$DST_REL"
+
+  case "$MODE" in
+    clean)
+      rm -f "$DST"
+      rmdir "$(dirname "$DST")" 2>/dev/null || true
+      echo "✓ removed $DST_REL"
+      ;;
+
+    deref)
+      if [[ ! -f "$SRC" ]]; then
+        echo "✗ canonical dataset missing: $SRC_REL" >&2
+        exit 1
+      fi
+
+      mkdir -p "$(dirname "$DST")"
+      cp -f "$SRC" "$DST"
+      chmod 644 "$DST"
+
+      if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$DST" 2>/dev/null; then
+        echo "✗ $DST_REL is not valid JSON after copy" >&2
+        exit 1
+      fi
+
+      echo "✓ materialised $DST_REL from $SRC_REL (build artefact, not committed)"
+      ;;
+
+    verify)
+      if [[ ! -f "$SRC" ]]; then
+        echo "✗ canonical dataset missing: $SRC_REL" >&2
+        exit 1
+      fi
+
+      if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))['currency_information']" "$SRC" 2>/dev/null; then
+        echo "✗ $SRC_REL is not valid currency data" >&2
+        exit 1
+      fi
+
+      # The package must never carry a committed copy of the dataset.
+      if git -C "$REPO_ROOT" ls-files --error-unmatch "$DST_REL" >/dev/null 2>&1; then
+        echo "✗ $DST_REL is tracked in git — the PHP package must read $SRC_REL directly." >&2
+        echo "  Run: git rm --cached '$DST_REL'" >&2
+        exit 1
+      fi
+
+      echo "✓ $SRC_REL is the single source; $DST_REL is not committed"
+      ;;
+  esac
+done


### PR DESCRIPTION
# Description

## Add `razorpay/i18nify-php` — PHP SDK (currency module)

i18nify shipped JS and Go only, so the invoice-formatting work in
[api#67103](https://github.com/razorpay/api/pull/67103) had to hand-port the
currency module into the monolith and vendor a copy of `currency.json` — two
sources of truth for one behaviour. This adds PHP as a first-class SDK so the
monolith keeps only thin wiring.

### What's in it

- `packages/i18nify-php/` — `Currency` (public API mirroring the JS surface:
  `formatNumber`, `formatNumberByParts`, `convertToMajorUnit`,
  `getCurrencySymbol`, `getMinorUnit`, …) and `FormatNumber` (ICU
  `NumberFormatter`, per-currency display-locale resolution).
- `formatSubunitsWithoutSymbol()` for the invoice/hosted-page case, plus the
  `INR -> en-IN`, else `en-US` locale mapping that previously lived in the
  monolith's `FormatsInvoiceAmounts` trait.
- PHPUnit suite covering the api PR's full matrix (INR lakh/crore grouping,
  international grouping, JPY 0-decimal, KWD 3-decimal, negatives).

### Data

No copy is committed. In the monorepo the SDK reads
`i18nify-data/currency/data.json` in place; the release pipeline materialises it
into the package only for published installs — the same build-artefact pattern
as the JS subsets and the Go embed. `scripts/php/sync-data.sh` enforces that no
duplicate is ever tracked.

### CI / release

- `php-validate.yml` — PHP 7.4 / 8.1 / 8.3, plus a parity check asserting PHP
  `ext-intl` output matches JS `Intl.NumberFormat` (both ICU/CLDR underneath).
- `php-release.yml` — subtree-splits `packages/i18nify-php/` into the read-only
  mirror `razorpay/i18nify-php` (Composer needs `composer.json` at a repo root)
  and tags it. Consumers point a `vcs` repository there, matching how every
  other `razorpay/*` package is consumed in api. No Packagist.
- Versioned by a `php:major` / `php:minor` / `php:patch` label, since changesets
  is npm-only.

**Needs the `php:major` label** — no `i18nify-php/v*` tag exists yet, so the
default patch bump would produce `v0.0.1` and api pins `^1.0`.

Prereq: empty repo `razorpay/i18nify-php` created, with `CI_BOT_TOKEN` write
access.

## Changes Made

List the main changes made in this pull request.

| Title                  | --- |
| ---------------------- | --- |
| JIRA link              | https://app.devrev.ai/razorpay/updates?dod=%5B%7B%22doi%22%3A%22don%3Acore%3Advrv-in-1%3Adevo%2F2sRI6Hepzz%3Aissue%2F3599865%22%2C%22dot%22%3A%22work%22%7D%5D&limit=15&priorities=high&states=unread |
| Slack thread (if any)  | https://razorpay.slack.com/archives/C7WEGELHJ/p1786428847974439 |
| Product spec           | NA  |
| Tech spec/One-pager    | NA  |
| Bundle Size Difference | NA  |
| Fixes Issue            | NA  |

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Is your change backward compatible ?
- [ ] Tested on major browsers (Chrome, Firefox, Safari, IE) ?
- [ ] Tested in a consumer application(s) ?

## Additional Notes

Any additional information that would be helpful for the reviewer.

## Checklist:

- [x] Add Jira ID(s) in PR title and in the description?
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code is written in TypeScript and follows the coding standards of the project.
- [x] I have added relevant documentation and updated the README if necessary.
- [x] My commit messages are clear and follow the project's commit message conventions.
- [x] Is any external library added?
- [x] My changes do not introduce any new runtime errors or warnings.
- [x] All relevant unit tests have been added/updated in my PR for the change.
- [x] Any Screenshots (mobile & desktop) required for PR? If yes, have you added the respective screenshots ?
- [x] Any manual dev testing done by you on beta/func environment?
- [x] Reviewer added (SLA 2 days)

## Reviewer Checklist

- [ ] Sufficient QA/Dev-Testing is done with proof (test cases list)
- [ ] Ensure that the change in bundle size falls within the acceptable range.

---
