### PR TITLE
chore: add servicetree.yaml manifest

### DIFF
--- a/servicetree.yaml
+++ b/servicetree.yaml
@@ -1,0 +1,37 @@
+service: i18nify  # required, canonical slug — immutable once registered
+displayName: "i18nify"  # required, human-readable name — README H1 "# i18nify"; the slug is the product name
+description: "Comprehensive internationalization (i18n) library — countries, currencies, phone numbers and subdivisions — published as Go, JavaScript and React packages (i18nify-go, i18nify-js, i18nify-react) over a shared i18nify-data dataset, used to localize Razorpay applications for different regions and languages."  # required, one-sentence description — README opening paragraph, its language-specific package links and the i18nify-data dataset section
+type: library  # required, one of: service | worker | cron | library | pipeline — a published multi-language library monorepo (packages/i18nify-{go,js,react}, i18nify-data); the proto files are for data definitions, and there is no Dockerfile, no Spinnaker application, no Netra deployment and no alert rules
+tier: T2  # required, one of: T0 | T1 | T2 | T3 — no priority column for this batch, judged from function: a shared library consumed by customer-facing localized surfaces across the org, so a bad release degrades many products at build time, but it has no runtime of its own to page on — T2 as org-wide supporting code
+lifecycle: live  # optional — actively maintained (last push 2026-09-08), publicly documented (deepwiki link) with published packages and contribution guidelines
+
+domain: cross-border/i18n  # required, two-level domain/subgroup slug — family cross-border from cache/miss_seed.json l1 (BU "I18N", csv_team "i18n Products"); new area "i18n" because no existing cross-border area (international-cards, apm, moneysaver, import) fits an internationalization library, and the area name matches the owning BU/pod verbatim
+
+owner:
+  team:  # required, owning team slug — TO FILL: this repo has no CODEOWNERS file, .github/repo_owners.json carries no team slug, and the GitHub repository-teams API is not readable with the current token; ask the POD lead for the owning GitHub team
+  em:  # name | @slack | email — TO FILL: DevRev runnable owner not found in SuccessFactors
+  org_group:  # SuccessFactors group of the EM — TO FILL: the declared owner has no SuccessFactors record, so the org tree cannot be resolved; ask the POD lead
+  org_sub_group:  # SuccessFactors sub-group of the EM — TO FILL: the declared owner has no SuccessFactors record; ask the POD lead
+  org_pod:  # SuccessFactors pod of the EM — TO FILL: the declared owner has no SuccessFactors record; ask the POD lead
+  pm:  # product manager — TO FILL: not derived on purpose; ask the I18N pod lead
+  overrides: []  # optional, region-scoped owner overrides — TO FILL only if some region is owned by a different team; each entry is a "region" code plus the owning "team" slug
+
+links:
+  repo: "https://github.com/razorpay/i18nify"  # canonical GitHub repo URL
+  alerts_repo:  # this service's alert rules in razorpay/alert-rules — TO FILL: no matching ruleset found; add one in razorpay/alert-rules, then link the file here
+  slos:  # SLO definitions — TO FILL: no slo.yaml at this repo root and no sloth ruleset for it under razorpay/alert-rules/slo/prod (the two places SLOs are defined today); add one there and link it here
+  slack_channel:  # primary Slack channel — TO FILL: no slack_candidates in the draft; ask the I18N pod lead for the i18nify channel
+  zenduty_policy:  # Zenduty policy/service name used for paging — TO FILL: the service-to-policy mapping is not in DevRev or alert-rules for this service; it lives in the external Zenduty policies sheet
+  escalation_l1:  # service EM — TO FILL: no owner could be resolved for this service
+  escalation_l2:  # EM's manager — TO FILL: the EM has no SuccessFactors record, so no manager chain is available
+  escalation_l3:  # manager's manager — TO FILL: the EM has no SuccessFactors record, so no manager chain is available
+  oncall_handle:  # Slack/PagerDuty oncall handle or usergroup — TO FILL: not set on the DevRev runnable
+  runbook:  # link to the incident runbook — TO FILL: no runbook directory for this service in razorpay/rzp-oncall-agent; add one or link the Google Doc / alpha.razorpay.com page
+  api_docs: "https://github.com/razorpay/i18nify/tree/master/proto"  # repo tree: gRPC .proto definitions under proto/
+  dashboard:  # primary dashboard — TO FILL: no Grafana hit and no alert rules; a client library has no runtime dashboard
+  logs_and_traces: "https://razorpay-prod.app.coralogix.in/#/query-new/archive-logs"  # org-standard prod Coralogix — filter subsystem "i18nify"
+  strategy_okr:  # TO FILL: link the FY strategy doc for the owning group.
+  risk_assessment:  # TO FILL: no .agents/skills/risk-assessment in this repo; add the per-repo risk-assessment skill
+  regions:  # per-region links — TO FILL: no prod region deployment found for this service in spinacode or alert-rules; add a block per geography once it ships
+
+dependencies: []  # optional, declared service dependencies — TO FILL: shape: - service: <slug> for internal deps, - vendor: <name> for external (gateways, banks)


### PR DESCRIPTION
Adds the Service Tree manifest (`servicetree.yaml`) to the repo root.

This manifest declares service ownership, tier, domain, and links for the Service Tree registry. Fields not yet sourced are left blank with inline comments.

Part of the Service Tree rollout.

Generated with Claude Code